### PR TITLE
Beta 2 updates

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,6 @@
 {
-    "version": "1.0.0beta1u1",
+    "version": "1.0.0beta2",
+    "location": "https://localhost:3000",
     "branding": {
         "name": "Hyperspace",
         "logo": "logo.svg",

--- a/public/config.json
+++ b/public/config.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0beta2",
-    "location": "https://localhost:3000",
+    "location": "https://hyperspaceapp-next.herokuapp.com",
     "branding": {
         "name": "Hyperspace",
         "logo": "logo.svg",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import SearchPage from './pages/Search';
 import Composer from './pages/Compose';
 import WelcomePage from './pages/Welcome';
 import MessagesPage from './pages/Messages';
+import RecommendationsPage from './pages/Recommendations';
 import {withSnackbar} from 'notistack';
 import {PrivateRoute} from './interfaces/overrides';
 import { userLoggedIn } from './utilities/accounts';
@@ -60,6 +61,7 @@ class App extends Component<any, any> {
             <PrivateRoute path="/settings" component={Settings}/>
             <PrivateRoute path="/about" component={AboutPage}/>
             <PrivateRoute path="/compose" component={Composer}/>
+            <PrivateRoute path="/recommended" component={RecommendationsPage}/>
           </div>
 
       </MuiThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import {MuiThemeProvider, CssBaseline, withStyles } from '@material-ui/core';
 import { setHyperspaceTheme, darkMode } from './utilities/themes';
 import AppLayout from './components/AppLayout';
 import {styles} from './App.styles';
-import {Route} from 'react-router-dom';
+import {Route, Switch} from 'react-router-dom';
 import AboutPage from './pages/About';
 import Settings from './pages/Settings';
 import { getUserDefaultBool, getUserDefaultTheme } from './utilities/settings';
@@ -18,6 +18,7 @@ import Composer from './pages/Compose';
 import WelcomePage from './pages/Welcome';
 import MessagesPage from './pages/Messages';
 import RecommendationsPage from './pages/Recommendations';
+import Missingno from './pages/Missingno';
 import {withSnackbar} from 'notistack';
 import {PrivateRoute} from './interfaces/overrides';
 import { userLoggedIn } from './utilities/accounts';
@@ -49,19 +50,22 @@ class App extends Component<any, any> {
         <Route path="/welcome" component={WelcomePage}/>
           <div>
             { userLoggedIn()? <AppLayout/>: null}
-            <PrivateRoute exact path="/" component={HomePage}/>
-            <PrivateRoute path="/home" component={HomePage}/>
-            <PrivateRoute path="/local" component={LocalPage}/>
-            <PrivateRoute path="/public" component={PublicPage}/>
-            <PrivateRoute path="/messages" component={MessagesPage}/>
-            <PrivateRoute path="/notifications" component={NotificationsPage}/>
-            <PrivateRoute path="/profile/:profileId" component={ProfilePage}/>
-            <PrivateRoute path="/conversation/:conversationId" component={Conversation}/>
-            <PrivateRoute path="/search" component={SearchPage}/>
-            <PrivateRoute path="/settings" component={Settings}/>
-            <PrivateRoute path="/about" component={AboutPage}/>
-            <PrivateRoute path="/compose" component={Composer}/>
-            <PrivateRoute path="/recommended" component={RecommendationsPage}/>
+            <Switch>
+              <PrivateRoute exact path="/" component={HomePage}/>
+              <PrivateRoute path="/home" component={HomePage}/>
+              <PrivateRoute path="/local" component={LocalPage}/>
+              <PrivateRoute path="/public" component={PublicPage}/>
+              <PrivateRoute path="/messages" component={MessagesPage}/>
+              <PrivateRoute path="/notifications" component={NotificationsPage}/>
+              <PrivateRoute path="/profile/:profileId" component={ProfilePage}/>
+              <PrivateRoute path="/conversation/:conversationId" component={Conversation}/>
+              <PrivateRoute path="/search" component={SearchPage}/>
+              <PrivateRoute path="/settings" component={Settings}/>
+              <PrivateRoute path="/about" component={AboutPage}/>
+              <PrivateRoute path="/compose" component={Composer}/>
+              <PrivateRoute path="/recommended" component={RecommendationsPage}/>
+              <PrivateRoute component={Missingno}/>
+            </Switch>
           </div>
 
       </MuiThemeProvider>

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -11,7 +11,7 @@ import GroupIcon from '@material-ui/icons/Group';
 import SettingsIcon from '@material-ui/icons/Settings';
 import InfoIcon from '@material-ui/icons/Info';
 import EditIcon from '@material-ui/icons/Edit';
-import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
+//import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import {styles} from './AppLayout.styles';
 import { UAccount } from '../../types/Account';
@@ -52,6 +52,7 @@ export class AppLayout extends Component<any, IAppLayoutState> {
     
         this.toggleDrawerOnMobile = this.toggleDrawerOnMobile.bind(this);
         this.toggleAcctMenu = this.toggleAcctMenu.bind(this);
+        this.clearBadge = this.clearBadge.bind(this);
       }
 
       componentDidMount() {
@@ -159,6 +160,12 @@ export class AppLayout extends Component<any, IAppLayoutState> {
             localStorage.removeItem(entry);
           })
           window.location.reload();
+        }
+      }
+
+      clearBadge() {
+        if (!getUserDefaultBool('displayAllOnNotificationBadge')) {
+          this.setState({ notificationCount: 0 });
         }
       }
 
@@ -288,7 +295,7 @@ export class AppLayout extends Component<any, IAppLayoutState> {
               <div className={classes.appBarFlexGrow}/>
               <div className={classes.appBarActionButtons}>
                   <Tooltip title="Notifications">
-                    <LinkableIconButton color="inherit" to="/notifications" onClick={() => this.setState({ notificationCount: 0 })}>
+                    <LinkableIconButton color="inherit" to="/notifications" onClick={this.clearBadge}>
                       <Badge badgeContent={this.state.notificationCount > 0? this.state.notificationCount: ""} color="secondary">
                         <NotificationsIcon />
                       </Badge>

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -198,18 +198,6 @@ export class AppLayout extends Component<any, IAppLayoutState> {
                     </ListItemAvatar>
                     <ListItemText primary={this.state.currentUser? (this.state.currentUser.display_name || this.state.currentUser.acct): "Loading..."} secondary={this.state.currentUser? this.state.currentUser.acct: "Loading..."}/>
                   </LinkableListItem>
-                  <LinkableListItem button key="notifications-mobile" to="/notifications">
-                    <ListItemIcon>
-                      <Badge badgeContent={this.state.notificationCount > 0? this.state.notificationCount: ""} color="secondary">
-                        <NotificationsIcon />
-                      </Badge>
-                    </ListItemIcon>
-                    <ListItemText primary="Notifications"/>
-                  </LinkableListItem>
-                  <LinkableListItem button key="messages-mobile" to="/messages">
-                    <ListItemIcon><MailIcon/></ListItemIcon>
-                    <ListItemText primary="Messages"/>
-                  </LinkableListItem>
                   {/* <LinkableListItem button key="acctSwitch-module" to="/switchacct">
                     <ListItemIcon><SupervisedUserCircleIcon/></ListItemIcon>
                     <ListItemText primary="Switch account"/>
@@ -241,6 +229,22 @@ export class AppLayout extends Component<any, IAppLayoutState> {
                     </ListItem>
                 }
                 <Divider/>
+                <div className={classes.drawerDisplayMobile}>
+                  <ListSubheader>Account</ListSubheader>
+                  <LinkableListItem button key="notifications-mobile" to="/notifications">
+                    <ListItemIcon>
+                      <Badge badgeContent={this.state.notificationCount > 0? this.state.notificationCount: ""} color="secondary">
+                        <NotificationsIcon />
+                      </Badge>
+                    </ListItemIcon>
+                    <ListItemText primary="Notifications"/>
+                  </LinkableListItem>
+                  <LinkableListItem button key="messages-mobile" to="/messages">
+                    <ListItemIcon><MailIcon/></ListItemIcon>
+                    <ListItemText primary="Messages"/>
+                  </LinkableListItem>
+                  <Divider/>
+                </div>
                 <ListSubheader>More</ListSubheader>
                 <LinkableListItem button key="recommended" to="/recommended">
                   <ListItemIcon><GroupIcon/></ListItemIcon>

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -238,9 +238,9 @@ export class AppLayout extends Component<any, IAppLayoutState> {
                 }
                 <Divider/>
                 <ListSubheader>More</ListSubheader>
-                <LinkableListItem button key="recommended" to="/recommended" disabled>
+                <LinkableListItem button key="recommended" to="/recommended">
                   <ListItemIcon><GroupIcon/></ListItemIcon>
-                  <ListItemText primary="Who to follow" secondary="Coming soon!"/>
+                  <ListItemText primary="Who to follow"/>
                 </LinkableListItem>
                 <LinkableListItem button key="settings" to="/settings">
                   <ListItemIcon><SettingsIcon/></ListItemIcon>

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -199,7 +199,11 @@ export class AppLayout extends Component<any, IAppLayoutState> {
                     <ListItemText primary={this.state.currentUser? (this.state.currentUser.display_name || this.state.currentUser.acct): "Loading..."} secondary={this.state.currentUser? this.state.currentUser.acct: "Loading..."}/>
                   </LinkableListItem>
                   <LinkableListItem button key="notifications-mobile" to="/notifications">
-                    <ListItemIcon><NotificationsIcon/></ListItemIcon>
+                    <ListItemIcon>
+                      <Badge badgeContent={this.state.notificationCount > 0? this.state.notificationCount: ""} color="secondary">
+                        <NotificationsIcon />
+                      </Badge>
+                    </ListItemIcon>
                     <ListItemText primary="Notifications"/>
                   </LinkableListItem>
                   <LinkableListItem button key="messages-mobile" to="/messages">

--- a/src/components/ThemePreview/ThemePreview.tsx
+++ b/src/components/ThemePreview/ThemePreview.tsx
@@ -20,10 +20,6 @@ class ThemePreview extends Component<IThemePreviewProps, IThemePreviewState> {
         }
     }
 
-    componentWillUpdate() {
-        console.log(this.props.theme);
-    }
-
     render() {
         return (
             <div style={{ position: 'relative' }}>

--- a/src/components/ThemePreview/ThemePreview.tsx
+++ b/src/components/ThemePreview/ThemePreview.tsx
@@ -1,0 +1,61 @@
+import React, {Component} from 'react';
+import {MuiThemeProvider, Theme, AppBar, Typography, CssBaseline, Toolbar, Fab, Paper} from '@material-ui/core';
+import EditIcon from '@material-ui/icons/Edit';
+import MenuIcon from '@material-ui/icons/Menu';
+
+interface IThemePreviewProps {
+    theme: Theme;
+}
+
+interface IThemePreviewState {
+    theme: Theme;
+}
+
+class ThemePreview extends Component<IThemePreviewProps, IThemePreviewState> {
+    constructor(props: IThemePreviewProps) {
+        super(props);
+
+        this.state = {
+            theme: this.props.theme
+        }
+    }
+
+    componentWillUpdate() {
+        console.log(this.props.theme);
+    }
+
+    render() {
+        return (
+            <div style={{ position: 'relative' }}>
+                <MuiThemeProvider theme={this.props.theme}>
+                    <CssBaseline/>
+                    <Paper>
+                        <AppBar color="primary" position="static">
+                            <Toolbar>
+                                <MenuIcon style={{ marginRight: 20, marginLeft: -4 }}/>
+                                <Typography variant="h6" color="inherit">Hyperspace</Typography>
+                            </Toolbar>
+                        </AppBar>
+                        <div style={{ paddingLeft: 16, paddingTop: 16, paddingRight: 16, paddingBottom: 16, flexGrow: 1 }}>
+                            <Typography variant="h4" component="p">
+                                This is your theme.
+                            </Typography>
+                            <br/>
+                            <Typography paragraph>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vestibulum congue sem ac ornare. In nec imperdiet neque. In eleifend laoreet efficitur. Vestibulum vel odio mattis, scelerisque nibh a, ornare lectus. Phasellus sollicitudin erat et turpis pellentesque consequat. In maximus luctus purus, eu molestie elit euismod eu. Pellentesque quam lectus, sagittis eget accumsan in, consequat ut sapien. Morbi aliquet ligula erat, id dapibus nunc laoreet at. Integer sodales lacinia finibus. Aliquam augue nibh, eleifend quis consectetur et, rhoncus ut odio. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                            </Typography>
+                        </div>
+                        <div style={{ textAlign: 'right' }}>
+                            <Fab color="secondary" style={{ marginRight: 8, marginBottom: 8 }}>
+                                <EditIcon/>
+                            </Fab>
+                        </div>
+
+                    </Paper>
+                </MuiThemeProvider>
+            </div>
+        )
+    }
+}
+
+export default ThemePreview;

--- a/src/components/ThemePreview/index.tsx
+++ b/src/components/ThemePreview/index.tsx
@@ -1,0 +1,3 @@
+import ThemePreview from './ThemePreview';
+
+export default ThemePreview;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -236,8 +236,8 @@ class AboutPage extends Component<any, IAboutPageState> {
                     </List>
                 </Paper>
                 <br/>
-                <div>
-                    <Typography variant="caption">(C) 2019 {this.state? this.state.brandName: "Hyperspace"} developers. All rights reserved.</Typography>
+                <div className={classes.pageLayoutFooter}>
+                    <Typography variant="caption">(C) {new Date().getFullYear()} {this.state? this.state.brandName: "Hyperspace"} developers. All rights reserved.</Typography>
                     <Typography variant="caption" paragraph>{this.state? this.state.brandName: "Hyperspace"} is made possible by the <Link href={"https://material-ui.com"} target="_blank" rel="noreferrer">Material UI</Link> project, <Link href={"https://www.npmjs.com/package/megalodon"} target="_blank" rel="noreferrer">Megalodon</Link> library, and other <Link href={"https://github.com/hyperspacedev/hyperspace/blob/master/package.json"} target="_blank" rel="noreferrer">open source software</Link>.</Typography>
                 </div>
             </div>

--- a/src/pages/Compose.tsx
+++ b/src/pages/Compose.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogContent, DialogActions, withStyles, Button, CardHeader, A
 import {parse as parseParams, ParsedQuery} from 'query-string';
 import {styles} from './Compose.styles';
 import { UAccount } from '../types/Account';
-import { Visibility } from '../types/Visibility';
+import { Visibility, toVisibility } from '../types/Visibility';
 import CameraAltIcon from '@material-ui/icons/CameraAlt';
 import TagFacesIcon from '@material-ui/icons/TagFaces';
 import HowToVoteIcon from '@material-ui/icons/HowToVote';
@@ -48,7 +48,7 @@ class Composer extends Component<any, IComposerState> {
 
         this.state = {
             account: JSON.parse(localStorage.getItem('account') as string),
-            visibility: "public",
+            visibility: (toVisibility(localStorage.getItem("defaultVisibility") as string) || "public"),
             sensitive: false,
             visibilityMenu: false,
             text: '',
@@ -95,7 +95,7 @@ class Composer extends Component<any, IComposerState> {
         let params = this.checkComposerParams(props.location);
         let reply: string = "";
         let acct: string = "";
-        let visibility: Visibility = "public";
+        let visibility= this.state.visibility;
 
         if (params.reply) {
             reply = params.reply.toString();
@@ -347,6 +347,7 @@ class Composer extends Component<any, IComposerState> {
 
     render() {
         const {classes} = this.props;
+        console.log(this.state);
 
         return (
             <Dialog open={true} maxWidth="sm" fullWidth={true} className={classes.dialog} onClose={() => window.history.back()}>

--- a/src/pages/Compose.tsx
+++ b/src/pages/Compose.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogContent, DialogActions, withStyles, Button, CardHeader, A
 import {parse as parseParams, ParsedQuery} from 'query-string';
 import {styles} from './Compose.styles';
 import { UAccount } from '../types/Account';
-import { Visibility, toVisibility } from '../types/Visibility';
+import { Visibility } from '../types/Visibility';
 import CameraAltIcon from '@material-ui/icons/CameraAlt';
 import TagFacesIcon from '@material-ui/icons/TagFaces';
 import HowToVoteIcon from '@material-ui/icons/HowToVote';
@@ -20,6 +20,7 @@ import ComposeMediaAttachment from '../components/ComposeMediaAttachment';
 import EmojiPicker from '../components/EmojiPicker';
 import { DateTimePicker, MuiPickersUtilsProvider } from 'material-ui-pickers';
 import MomentUtils from '@date-io/moment';
+import { getUserDefaultVisibility } from '../utilities/settings';
 
 interface IComposerState {
     account: UAccount;
@@ -48,7 +49,7 @@ class Composer extends Component<any, IComposerState> {
 
         this.state = {
             account: JSON.parse(localStorage.getItem('account') as string),
-            visibility: (toVisibility(localStorage.getItem("defaultVisibility") as string) || "public"),
+            visibility: getUserDefaultVisibility(),
             sensitive: false,
             visibilityMenu: false,
             text: '',

--- a/src/pages/Missingno.tsx
+++ b/src/pages/Missingno.tsx
@@ -1,0 +1,25 @@
+import React, {Component} from 'react';
+import {withStyles, Typography} from '@material-ui/core';
+import {styles} from './PageLayout.styles';
+import {LinkableButton} from '../interfaces/overrides';
+
+class Missingno extends Component<any, any> {
+
+    render() {
+        const {classes} = this.props;
+        return (
+            <div className={classes.pageLayoutConstraints}>
+                <div>
+                    <Typography variant="h4" component="h1"><b>Uh oh!</b></Typography>
+                    <Typography variant="h6" component="p">The part of Hyperspace you're looking for isn't here.</Typography>
+                    <br/>
+                    <LinkableButton to="/home" color="primary" variant="contained">
+                        Go back to home timeline
+                    </LinkableButton>
+                </div>
+            </div>
+        )
+    }
+}
+
+export default withStyles(styles)(Missingno);

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -80,7 +80,8 @@ class NotificationsPage extends Component<any, INotificationsPageState> {
         const div = document.createElement('div');
         div.innerHTML = text;
         let innerContent = div.textContent || div.innerText || "";
-        innerContent = innerContent.slice(0, 85) + "..."
+        if (innerContent.length > 65)
+            innerContent = innerContent.slice(0, 65) + "...";
         return innerContent;
     }
 
@@ -115,6 +116,7 @@ class NotificationsPage extends Component<any, INotificationsPageState> {
     }
 
     createNotification(notif: Notification) {
+        const { classes } = this.props;
         let primary = "";
         let secondary = "";
         switch (notif.type) {
@@ -149,7 +151,16 @@ class NotificationsPage extends Component<any, INotificationsPageState> {
                         <PersonIcon/>
                     </Avatar>
                 </ListItemAvatar>
-                <ListItemText primary={primary} secondary={secondary}/>
+                <ListItemText primary={primary} secondary={
+                    <span>
+                        <Typography color="textSecondary" className={classes.mobileOnly}>
+                            {secondary.slice(0, 35) + "..."}
+                        </Typography>
+                        <Typography color="textSecondary" className={classes.desktopOnly}>
+                            {secondary}
+                        </Typography>
+                    </span>
+                }/>
                 <ListItemSecondaryAction>
                     {
                         notif.type === "follow"?

--- a/src/pages/PageLayout.styles.tsx
+++ b/src/pages/PageLayout.styles.tsx
@@ -169,5 +169,10 @@ export const styles = (theme: Theme) => createStyles({
       [theme.breakpoints.up('sm')]: {
         display: 'block'
       }
+    },
+    pageLayoutFooter: {
+      '& a': {
+        color: theme.palette.primary.light
+      }
     }
   });

--- a/src/pages/Recommendations.tsx
+++ b/src/pages/Recommendations.tsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {withStyles, Typography, List, ListItem, Paper, ListItemText, Avatar, ListItemSecondaryAction, ListItemAvatar, ListSubheader, CircularProgress, IconButton, Divider} from '@material-ui/core';
+import {withStyles, Typography, List, ListItem, Paper, ListItemText, Avatar, ListItemSecondaryAction, ListItemAvatar, ListSubheader, CircularProgress, IconButton, Divider, Tooltip} from '@material-ui/core';
 import {styles} from './PageLayout.styles';
 import Mastodon from 'megalodon';
 import {Account} from '../types/Account';
@@ -124,15 +124,21 @@ class RecommendationsPage extends Component<IRecommendationsPageProps, IRecommen
                                             </ListItemAvatar>
                                             <ListItemText primary={request.display_name || request.acct} secondary={request.acct}/>
                                             <ListItemSecondaryAction>
-                                                <IconButton onClick={() => this.handleFollowRequest(request, "authorize")}>
-                                                    <CheckIcon/>
-                                                </IconButton>
-                                                <IconButton onClick={() => this.handleFollowRequest(request, "reject")}>
-                                                    <CloseIcon/>
-                                                </IconButton>
-                                                <LinkableIconButton to={`/profile/${request.id}`}>
-                                                    <AccountCircleIcon/>
-                                                </LinkableIconButton>
+                                                <Tooltip title="Accept request">
+                                                    <IconButton onClick={() => this.handleFollowRequest(request, "authorize")}>
+                                                        <CheckIcon/>
+                                                    </IconButton>
+                                                </Tooltip>
+                                                <Tooltip title="Reject request">
+                                                    <IconButton onClick={() => this.handleFollowRequest(request, "reject")}>
+                                                        <CloseIcon/>
+                                                    </IconButton>
+                                                </Tooltip>
+                                                <Tooltip title="View profile">
+                                                    <LinkableIconButton to={`/profile/${request.id}`}>
+                                                        <AccountCircleIcon/>
+                                                    </LinkableIconButton>
+                                                </Tooltip>
                                             </ListItemSecondaryAction>
                                         </ListItem>
                                     );
@@ -162,12 +168,16 @@ class RecommendationsPage extends Component<IRecommendationsPageProps, IRecommen
                                             </ListItemAvatar>
                                             <ListItemText primary={suggestion.display_name || suggestion.acct} secondary={suggestion.acct}/>
                                             <ListItemSecondaryAction>
-                                                <IconButton onClick={() => this.followMember(suggestion)}>
-                                                    <PersonAddIcon/>
-                                                </IconButton>
-                                                <LinkableIconButton to={`/profile/${suggestion.id}`}>
-                                                    <AccountCircleIcon/>
-                                                </LinkableIconButton>
+                                                <Tooltip title="Follow">
+                                                    <IconButton onClick={() => this.followMember(suggestion)}>
+                                                        <PersonAddIcon/>
+                                                    </IconButton>
+                                                </Tooltip>
+                                                <Tooltip title="View profile">
+                                                    <LinkableIconButton to={`/profile/${suggestion.id}`}>
+                                                        <AccountCircleIcon/>
+                                                    </LinkableIconButton>
+                                                </Tooltip>
                                             </ListItemSecondaryAction>
                                         </ListItem>
                                     );

--- a/src/pages/Recommendations.tsx
+++ b/src/pages/Recommendations.tsx
@@ -1,0 +1,228 @@
+import React, {Component} from 'react';
+import {withStyles, Typography, List, ListItem, Paper, ListItemText, Avatar, ListItemSecondaryAction, ListItemAvatar, ListSubheader, CircularProgress, IconButton, Divider} from '@material-ui/core';
+import {styles} from './PageLayout.styles';
+import Mastodon from 'megalodon';
+import {Account} from '../types/Account';
+import { LinkableIconButton } from '../interfaces/overrides';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import PersonAddIcon from '@material-ui/icons/PersonAdd';
+import CheckIcon from '@material-ui/icons/Check';
+import CloseIcon from '@material-ui/icons/Close';
+import {withSnackbar, withSnackbarProps} from 'notistack';
+
+interface IRecommendationsPageProps extends withSnackbarProps {
+    classes: any;
+}
+
+interface IRecommendationsPageState {
+    viewIsLoading: boolean;
+    viewDidLoad?: boolean;
+    viewDidError?: Boolean;
+    viewDidErrorCode?: string;
+    requestedFollows?: [Account];
+    followSuggestions?: [Account];
+}
+
+class RecommendationsPage extends Component<IRecommendationsPageProps, IRecommendationsPageState> {
+
+    client: Mastodon;
+
+    constructor(props: any) {
+        super(props);
+        this.client = new Mastodon(localStorage.getItem('access_token') as string, localStorage.getItem('baseurl') + "/api/v1");
+        this.state = {
+            viewIsLoading: true
+        }
+    }
+
+    componentDidMount() {
+        this.client.get('/follow_requests').then((resp: any) => {
+            let requestedFollows: [Account] = resp.data;
+            this.setState({ requestedFollows })
+        }).catch((err: Error) => {
+            this.setState({
+                viewIsLoading: false,
+                viewDidError: true,
+                viewDidErrorCode: err.name
+            });
+            console.error(err.message);
+        })
+
+        this.client.get('/suggestions').then((resp: any) => {
+            let followSuggestions: [Account] = resp.data;
+            this.setState({
+                viewIsLoading: false,
+                viewDidLoad: true,
+                followSuggestions
+            })
+        }).catch((err: Error) => {
+            this.setState({
+                viewIsLoading: false,
+                viewDidError: true,
+                viewDidErrorCode: err.name
+            });
+            console.error(err.message);
+        })
+    }
+
+    followMember(acct: Account) {
+        this.client.post(`/accounts/${acct.id}/follow`).then((resp: any) => {
+            this.props.enqueueSnackbar('You are now following this account.');
+            this.client.del(`/suggestions/${acct.id}`).then((resp: any) => {
+                let followSuggestions = this.state.followSuggestions;
+                if (followSuggestions) {
+                    followSuggestions.forEach((suggestion: Account, index: number) => {
+                        if (followSuggestions && suggestion.id === acct.id) {
+                            followSuggestions.splice(index, 1);
+                        }
+                    });
+                    this.setState({ followSuggestions });
+                }
+            })
+        }).catch((err: Error) => {
+            this.props.enqueueSnackbar("Couldn't follow account: " + err.name, { variant: 'error' });
+            console.error(err.message);
+        })
+    }
+
+    handleFollowRequest(acct: Account, type: "authorize" | "reject") {
+        this.client.post(`/follow_requests/${acct.id}/${type}`).then((resp: any) => {
+
+            let requestedFollows = this.state.requestedFollows;
+            if (requestedFollows) {
+                requestedFollows.forEach((request: Account, index: number) => {
+                    if (requestedFollows && request.id === acct.id) {
+                        requestedFollows.splice(index, 1);
+                    };
+                });
+            };
+            this.setState({requestedFollows});
+
+            let verb: string = type;
+            verb === "authorize"? verb = "authorized": verb = "rejected";
+            this.props.enqueueSnackbar(`You have ${verb} this request.`);
+        }).catch((err: Error) => {
+            this.props.enqueueSnackbar(`Couldn't ${type} this request: ${err.name}`, { variant: 'error' });
+            console.error(err.message);
+        })
+    }
+
+    showFollowRequests() {
+        const {classes} = this.props;
+        return (
+            <div>
+                <ListSubheader>Follow requests</ListSubheader>
+                    <Paper className={classes.pageListConstraints}>
+                        <List>
+                            {
+                                this.state.requestedFollows?
+                                    this.state.requestedFollows.map((request: Account) => {
+                                        return (
+                                        <ListItem key={request.id}>
+                                            <ListItemAvatar>
+                                                <Avatar alt={request.username} src={request.avatar_static}/>
+                                            </ListItemAvatar>
+                                            <ListItemText primary={request.display_name || request.acct} secondary={request.acct}/>
+                                            <ListItemSecondaryAction>
+                                                <IconButton onClick={() => this.handleFollowRequest(request, "authorize")}>
+                                                    <CheckIcon/>
+                                                </IconButton>
+                                                <IconButton onClick={() => this.handleFollowRequest(request, "reject")}>
+                                                    <CloseIcon/>
+                                                </IconButton>
+                                                <LinkableIconButton to={`/profile/${request.id}`}>
+                                                    <AccountCircleIcon/>
+                                                </LinkableIconButton>
+                                            </ListItemSecondaryAction>
+                                        </ListItem>
+                                    );
+                                    }): null
+                            }
+                        </List>
+                    </Paper>
+                <br/>
+            </div>
+        )
+    }
+
+    showFollowSuggestions() {
+        const {classes} = this.props;
+        return (
+            <div>
+                <ListSubheader>Suggested accounts</ListSubheader>
+                    <Paper className={classes.pageListConstraints}>
+                        <List>
+                            {
+                                this.state.followSuggestions?
+                                    this.state.followSuggestions.map((suggestion: Account) => {
+                                        return (
+                                        <ListItem key={suggestion.id}>
+                                            <ListItemAvatar>
+                                                <Avatar alt={suggestion.username} src={suggestion.avatar_static}/>
+                                            </ListItemAvatar>
+                                            <ListItemText primary={suggestion.display_name || suggestion.acct} secondary={suggestion.acct}/>
+                                            <ListItemSecondaryAction>
+                                                <IconButton onClick={() => this.followMember(suggestion)}>
+                                                    <PersonAddIcon/>
+                                                </IconButton>
+                                                <LinkableIconButton to={`/profile/${suggestion.id}`}>
+                                                    <AccountCircleIcon/>
+                                                </LinkableIconButton>
+                                            </ListItemSecondaryAction>
+                                        </ListItem>
+                                    );
+                                    }): null
+                            }
+                        </List>
+                    </Paper>
+                <br/>
+            </div>
+        )
+    }
+
+    render() {
+        const {classes} = this.props;
+        return (
+            <div className={classes.pageLayoutConstraints}>
+                {
+                    this.state.viewDidLoad?
+                        <div>
+                            {
+                                this.state.requestedFollows && this.state.requestedFollows.length > 0?
+                                this.showFollowRequests():
+                                <div>
+                                    <Typography variant="h6">You don't have any follow requests.</Typography>
+                                    <br/>
+                                </div>
+                            }
+                            <Divider/>
+                            <br/>
+                            {
+                                this.state.followSuggestions && this.state.followSuggestions.length > 0? this.showFollowSuggestions(): 
+                                <div>
+                                    <Typography variant="h5">We don't have any suggestions for you.</Typography>
+                                    <Typography paragraph>Why not interact with the fediverse a bit by creating a new post?</Typography>
+                                </div>
+                            }
+                        </div>: null
+                }
+                {
+                    this.state.viewDidError? 
+                        <Paper className={classes.errorCard}>
+                            <Typography variant="h4">Bummer.</Typography>
+                            <Typography variant="h6">Something went wrong when loading this timeline.</Typography>
+                            <Typography>{this.state.viewDidErrorCode? this.state.viewDidErrorCode: ""}</Typography>
+                        </Paper>: 
+                        <span/>
+                }
+                {
+                    this.state.viewIsLoading?
+                    <div style={{ textAlign: 'center' }}><CircularProgress className={classes.progress} color="primary" /></div>:
+                    <span/>
+                }
+            </div>
+        );
+    }
+}
+
+export default withStyles(styles)(withSnackbar(RecommendationsPage));

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -23,7 +23,7 @@ import {
 } from '@material-ui/core';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import {styles} from './PageLayout.styles';
-import {setUserDefaultBool, getUserDefaultBool, getUserDefaultTheme, setUserDefaultTheme} from '../utilities/settings';
+import {setUserDefaultBool, getUserDefaultBool, getUserDefaultTheme, setUserDefaultTheme, getUserDefaultVisibility, setUserDefaultVisibility} from '../utilities/settings';
 import {canSendNotifications, browserSupportsNotificationRequests} from '../utilities/notifications';
 import {themes, defaultTheme} from '../types/HyperspaceTheme';
 import ThemePreview from '../components/ThemePreview';
@@ -58,7 +58,7 @@ class SettingsPage extends Component<any, ISettingsState> {
             resetHyperspaceDialog: false,
             resetSettingsDialog: false,
             previewTheme: setHyperspaceTheme(getUserDefaultTheme()) || setHyperspaceTheme(defaultTheme),
-            defaultVisibility: localStorage.getItem('defaultVisibility')? toVisibility(localStorage.getItem("defautlVisibility") as string) : "public"
+            defaultVisibility: getUserDefaultVisibility() || "public"
         }
 
         this.toggleDarkMode = this.toggleDarkMode.bind(this);
@@ -118,7 +118,7 @@ class SettingsPage extends Component<any, ISettingsState> {
     }
 
     setVisibility() {
-        localStorage.setItem('defaultVisibility', this.state.defaultVisibility);
+        setUserDefaultVisibility(this.state.defaultVisibility);
         this.toggleVisibilityDialog();
     }
 
@@ -128,7 +128,7 @@ class SettingsPage extends Component<any, ISettingsState> {
     }
 
     refresh() {
-        let settings = ['darkModeEnabled', 'enablePushNotifications', 'clearNotificationsOnRead', 'theme', 'displayAllOnNotificationBadge'];
+        let settings = ['darkModeEnabled', 'enablePushNotifications', 'clearNotificationsOnRead', 'theme', 'displayAllOnNotificationBadge', 'defaultVisibility'];
         settings.forEach(setting => {
             localStorage.removeItem(setting);
         })

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -358,23 +358,20 @@ class SettingsPage extends Component<any, ISettingsState> {
                                 />
                             </ListItemSecondaryAction>
                         </ListItem>
-                        {
-                            browserSupportsNotificationRequests()?
-                            <ListItem>
-                                <ListItemText 
-                                    primary="Notification badge counts all notifications"
-                                    secondary={
-                                        "Counts all notifications, read or unread."
-                                    }
+                        <ListItem>
+                            <ListItemText 
+                                primary="Notification badge counts all notifications"
+                                secondary={
+                                    "Counts all notifications, read or unread."
+                                }
+                            />
+                            <ListItemSecondaryAction>
+                                <Switch 
+                                    checked={this.state.badgeDisplaysAllNotifs} 
+                                    onChange={this.toggleBadgeCount}
                                 />
-                                <ListItemSecondaryAction>
-                                    <Switch 
-                                        checked={this.state.badgeDisplaysAllNotifs} 
-                                        onChange={this.toggleBadgeCount}
-                                    />
-                                </ListItemSecondaryAction>
-                            </ListItem>: null
-                        }
+                            </ListItemSecondaryAction>
+                        </ListItem>
                     </List>
                 </Paper>
                 <br/>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,13 +17,17 @@ import {
     FormControlLabel,
     Radio,
     DialogActions,
-    DialogContentText
+    DialogContentText,
+    Grid,
+    Theme
 } from '@material-ui/core';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import {styles} from './PageLayout.styles';
 import {setUserDefaultBool, getUserDefaultBool, getUserDefaultTheme, setUserDefaultTheme} from '../utilities/settings';
 import {canSendNotifications, browserSupportsNotificationRequests} from '../utilities/notifications';
-import {themes} from '../types/HyperspaceTheme';
+import {themes, defaultTheme} from '../types/HyperspaceTheme';
+import ThemePreview from '../components/ThemePreview';
+import {setHyperspaceTheme, getHyperspaceTheme} from '../utilities/themes';
 
 interface ISettingsState {
     darkModeEnabled: boolean;
@@ -33,6 +37,7 @@ interface ISettingsState {
     themeDialogOpen: boolean;
     resetHyperspaceDialog: boolean;
     resetSettingsDialog: boolean;
+    previewTheme: Theme;
 }
 
 class SettingsPage extends Component<any, ISettingsState> {
@@ -47,7 +52,8 @@ class SettingsPage extends Component<any, ISettingsState> {
             selectThemeName: getUserDefaultTheme().key,
             themeDialogOpen: false,
             resetHyperspaceDialog: false,
-            resetSettingsDialog: false
+            resetSettingsDialog: false,
+            previewTheme: setHyperspaceTheme(getUserDefaultTheme()) || setHyperspaceTheme(defaultTheme)
         }
 
         this.toggleDarkMode = this.toggleDarkMode.bind(this);
@@ -92,7 +98,8 @@ class SettingsPage extends Component<any, ISettingsState> {
     }
 
     changeThemeName(theme: string) {
-        this.setState({ selectThemeName: theme});
+        let previewTheme = setHyperspaceTheme(getHyperspaceTheme(theme));
+        this.setState({ selectThemeName: theme, previewTheme });
     }
 
     reset() {
@@ -101,7 +108,7 @@ class SettingsPage extends Component<any, ISettingsState> {
     }
 
     refresh() {
-        let settings = ['darkModeEnabled', 'enablePushNotifications', 'clearNotificationsOnRead', 'theme'];
+        let settings = ['darkModeEnabled', 'enablePushNotifications', 'clearNotificationsOnRead', 'theme', 'displayAllOnNotificationBadge'];
         settings.forEach(setting => {
             localStorage.removeItem(setting);
         })
@@ -109,35 +116,43 @@ class SettingsPage extends Component<any, ISettingsState> {
     }
 
     showThemeDialog() {
+        const {classes} = this.props;
         return (
             <Dialog
                 open={this.state.themeDialogOpen}
                 disableBackdropClick
                 disableEscapeKeyDown
-                maxWidth="sm"
+                maxWidth="md"
                 fullWidth={true}
                 aria-labelledby="confirmation-dialog-title"
             >
                 <DialogTitle id="confirmation-dialog-title">Choose a color scheme</DialogTitle>
                 <DialogContent>
-                    <RadioGroup
-                        aria-label="Color Scheme"
-                        name="ringtone"
-                        value={this.state.selectThemeName}
-                        onChange={(e, value) => this.changeThemeName(value)}
-                    >
-                        {themes.map(theme => (
-                            <FormControlLabel value={theme.key} key={theme.key} control={<Radio />} label={theme.name} />
-                        ))}
-                        ))}
-                    </RadioGroup>
+                    <Grid container spacing={16}>
+                        <Grid item xs={12} md={6}>
+                            <RadioGroup
+                                aria-label="Color Scheme"
+                                name="colorScheme"
+                                value={this.state.selectThemeName}
+                                onChange={(e, value) => this.changeThemeName(value)}
+                            >
+                                {themes.map(theme => (
+                                    <FormControlLabel value={theme.key} key={theme.key} control={<Radio />} label={theme.name} />
+                                ))}
+                                ))}
+                            </RadioGroup>
+                        </Grid>
+                        <Grid item xs={12} md={6} className={classes.desktopOnly}>
+                            <ThemePreview theme={this.state.previewTheme}/>
+                        </Grid>
+                    </Grid>
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={this.toggleThemeDialog} color="default">
                         Cancel
                     </Button>
                     <Button onClick={this.changeTheme} color="secondary">
-                        Ok
+                        Set theme
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -19,7 +19,8 @@ import {
     DialogActions,
     DialogContentText,
     Grid,
-    Theme
+    Theme,
+    Typography
 } from '@material-ui/core';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import {styles} from './PageLayout.styles';
@@ -172,6 +173,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                             </RadioGroup>
                         </Grid>
                         <Grid item xs={12} md={6} className={classes.desktopOnly}>
+                            <Typography variant="h6" component="p">Theme preview</Typography>
                             <ThemePreview theme={this.state.previewTheme}/>
                         </Grid>
                     </Grid>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -28,10 +28,11 @@ import {canSendNotifications, browserSupportsNotificationRequests} from '../util
 import {themes, defaultTheme} from '../types/HyperspaceTheme';
 import ThemePreview from '../components/ThemePreview';
 import {setHyperspaceTheme, getHyperspaceTheme} from '../utilities/themes';
-import { Visibility, toVisibility } from '../types/Visibility';
+import { Visibility } from '../types/Visibility';
 
 interface ISettingsState {
     darkModeEnabled: boolean;
+    systemDecidesDarkMode: boolean;
     pushNotificationsEnabled: boolean;
     badgeDisplaysAllNotifs: boolean;
     selectThemeName: string;
@@ -50,6 +51,7 @@ class SettingsPage extends Component<any, ISettingsState> {
 
         this.state = {
             darkModeEnabled: getUserDefaultBool('darkModeEnabled'),
+            systemDecidesDarkMode: getUserDefaultBool('systemDecidesDarkMode'),
             pushNotificationsEnabled: canSendNotifications(),
             badgeDisplaysAllNotifs: getUserDefaultBool('displayAllOnNotificationBadge'),
             selectThemeName: getUserDefaultTheme().key,
@@ -62,6 +64,7 @@ class SettingsPage extends Component<any, ISettingsState> {
         }
 
         this.toggleDarkMode = this.toggleDarkMode.bind(this);
+        this.toggleSystemDarkMode = this.toggleSystemDarkMode.bind(this);
         this.togglePushNotifications = this.togglePushNotifications.bind(this);
         this.toggleBadgeCount = this.toggleBadgeCount.bind(this);
         this.toggleThemeDialog = this.toggleThemeDialog.bind(this);
@@ -74,6 +77,12 @@ class SettingsPage extends Component<any, ISettingsState> {
     toggleDarkMode() {
         this.setState({ darkModeEnabled: !this.state.darkModeEnabled });
         setUserDefaultBool('darkModeEnabled', !this.state.darkModeEnabled);
+        window.location.reload();
+    }
+
+    toggleSystemDarkMode() {
+        this.setState({ systemDecidesDarkMode: !this.state.systemDecidesDarkMode });
+        setUserDefaultBool('systemDecidesDarkMode', !this.state.systemDecidesDarkMode);
         window.location.reload();
     }
 
@@ -270,9 +279,22 @@ class SettingsPage extends Component<any, ISettingsState> {
                 <Paper className={classes.pageListConstraints}>
                     <List>
                         <ListItem>
+                            <ListItemText primary="Match system appearance" secondary="Obey light/dark mode from your system"/>
+                            <ListItemSecondaryAction>
+                                <Switch 
+                                    checked={this.state.systemDecidesDarkMode} 
+                                    onChange={this.toggleSystemDarkMode}
+                                />
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
                             <ListItemText primary="Dark mode"/>
                             <ListItemSecondaryAction>
-                                <Switch checked={this.state.darkModeEnabled} onChange={this.toggleDarkMode}/>
+                                <Switch
+                                    disabled={this.state.systemDecidesDarkMode}
+                                    checked={this.state.darkModeEnabled} 
+                                    onChange={this.toggleDarkMode}
+                                />
                             </ListItemSecondaryAction>
                         </ListItem>
                         <ListItem>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -275,7 +275,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                 <Paper className={classes.pageListConstraints}>
                     <List>
                         <ListItem>
-                            <ListItemText primary="Refresh settings" secondary="Reset Hyperspace to its default settings."/>
+                            <ListItemText primary="Refresh settings" secondary="Reset the settings to defaults."/>
                             <ListItemSecondaryAction>
                                 <Button onClick={() => this.toggleResetSettingsDialog()}>
                                     Refresh

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -279,7 +279,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                 <Paper className={classes.pageListConstraints}>
                     <List>
                         <ListItem>
-                            <ListItemText primary="Match system appearance" secondary="Obey light/dark mode from your system"/>
+                            <ListItemText primary="Match system appearance" secondary="Obey light/dark theme from your system"/>
                             <ListItemSecondaryAction>
                                 <Switch 
                                     checked={this.state.systemDecidesDarkMode} 
@@ -288,7 +288,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                             </ListItemSecondaryAction>
                         </ListItem>
                         <ListItem>
-                            <ListItemText primary="Dark mode"/>
+                            <ListItemText primary="Dark mode" secondary="Toggles light or dark theme"/>
                             <ListItemSecondaryAction>
                                 <Switch
                                     disabled={this.state.systemDecidesDarkMode}
@@ -298,7 +298,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                             </ListItemSecondaryAction>
                         </ListItem>
                         <ListItem>
-                            <ListItemText primary="Interface theme"/>
+                            <ListItemText primary="Interface theme" secondary="The color palette used for the interface"/>
                             <ListItemSecondaryAction>
                                 <Button onClick={this.toggleThemeDialog}>
                                     Set theme

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -126,12 +126,12 @@ class SettingsPage extends Component<any, ISettingsState> {
                 fullWidth={true}
                 aria-labelledby="confirmation-dialog-title"
             >
-                <DialogTitle id="confirmation-dialog-title">Choose a color scheme</DialogTitle>
+                <DialogTitle id="confirmation-dialog-title">Choose a theme</DialogTitle>
                 <DialogContent>
                     <Grid container spacing={16}>
                         <Grid item xs={12} md={6}>
                             <RadioGroup
-                                aria-label="Color Scheme"
+                                aria-label="Theme"
                                 name="colorScheme"
                                 value={this.state.selectThemeName}
                                 onChange={(e, value) => this.changeThemeName(value)}
@@ -220,7 +220,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                             </ListItemSecondaryAction>
                         </ListItem>
                         <ListItem>
-                            <ListItemText primary="Color scheme"/>
+                            <ListItemText primary="Interface theme"/>
                             <ListItemSecondaryAction>
                                 <Button onClick={this.toggleThemeDialog}>
                                     Set theme

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -319,7 +319,7 @@ class WelcomePage extends Component<any, IWelcomeState> {
                 </Fade>
                 <br/>
                 <Typography variant="caption">
-                    &copy; 2019 <Link href="https://hyperspace.marquiskurt.net" target="_blank" rel="noreferrer">Hyperspace</Link> developers. All rights reserved.
+                    &copy; {new Date().getFullYear()} {this.state.brandName && this.state.brandName !== "Hyperspace"? `${this.state.brandName} developers and the `: ""}<Link href="https://hyperspace.marquiskurt.net" target="_blank" rel="noreferrer">Hyperspace</Link> developers. All rights reserved.
                 </Typography>
                 <Typography variant="caption">
                 { this.state.repo? <span><Link href={this.state.repo? this.state.repo: "https://github.com/hyperspacedev"} target="_blank" rel="noreferrer">Source code</Link>  | </span>: null}<Link href={this.state.license? this.state.license: "https://www.apache.org/licenses/LICENSE-2.0"} target="_blank" rel="noreferrer">License</Link> | <Link href="https://github.com/hyperspacedev/hyperspace/issues/new" target="_blank" rel="noreferrer">File an Issue</Link>

--- a/src/pages/WelcomePage.styles.tsx
+++ b/src/pages/WelcomePage.styles.tsx
@@ -33,7 +33,10 @@ export const styles = (theme: Theme) => createStyles({
         paddingLeft: theme.spacing.unit * 4,
         paddingRight: theme.spacing.unit * 4,
         paddingBottom: theme.spacing.unit * 6,
-        textAlign: 'center'
+        textAlign: 'center',
+        '& a': {
+            color: theme.palette.primary.light
+        }
     },
     flexGrow: {
         flexGrow: 1

--- a/src/types/Config.tsx
+++ b/src/types/Config.tsx
@@ -1,5 +1,6 @@
 export type Config = {
     version: string;
+    location: string;
     branding?: {
         name?: string;
         logo?: string;

--- a/src/types/HyperspaceTheme.tsx
+++ b/src/types/HyperspaceTheme.tsx
@@ -19,7 +19,7 @@ export type HyperspaceTheme = {
 
 export const defaultTheme: HyperspaceTheme = {
     key: "defaultTheme",
-    name: "Hypergod (Default)",
+    name: "Royal (Default)",
     palette: {
         primary: deepPurple,
         secondary: red
@@ -28,7 +28,7 @@ export const defaultTheme: HyperspaceTheme = {
 
 export const gardenerTheme: HyperspaceTheme = {
     key: "gardnerTheme",
-    name: "Gardener",
+    name: "Botanical",
     palette: {
         primary: lightGreen,
         secondary: yellow
@@ -37,7 +37,7 @@ export const gardenerTheme: HyperspaceTheme = {
 
 export const teacherTheme: HyperspaceTheme = {
     key: "teacherTheme",
-    name: "Teacher",
+    name: "Compassionate",
     palette: {
         primary: purple,
         secondary: deepOrange
@@ -53,36 +53,18 @@ export const jokerTheme: HyperspaceTheme = {
     }
 }
 
-export const brotherTheme: HyperspaceTheme = {
-    key: "brotherTheme",
-    name: "Brother",
-    palette: {
-        primary: red,
-        secondary: orange
-    }
-}
-
 export const guardTheme: HyperspaceTheme = {
     key: "guardTheme",
-    name: "Guard",
+    name: "Enthusiastic",
     palette: {
         primary: blue,
         secondary: deepOrange
     }
 }
 
-export const scientistTheme: HyperspaceTheme = {
-    key: "scientistTheme",
-    name: "Scientist",
-    palette: {
-        primary: amber,
-        secondary: yellow
-    }
-}
-
 export const entertainerTheme: HyperspaceTheme = {
     key: "entertainerTheme",
-    name: "Entertainer",
+    name: "Animated",
     palette: {
         primary: pink,
         secondary: purple
@@ -91,7 +73,7 @@ export const entertainerTheme: HyperspaceTheme = {
 
 export const kingTheme: HyperspaceTheme = {
     key: "kingTheme",
-    name: "King",
+    name: "Royal II",
     palette: {
         primary: deepPurple,
         secondary: amber
@@ -100,7 +82,7 @@ export const kingTheme: HyperspaceTheme = {
 
 export const dragonTheme: HyperspaceTheme = {
     key: "dragonTheme",
-    name: "Dragon",
+    name: "Adventurous",
     palette: {
         primary: purple,
         secondary: purple
@@ -109,7 +91,7 @@ export const dragonTheme: HyperspaceTheme = {
 
 export const memoriumTheme: HyperspaceTheme = {
     key: "memoriumTheme",
-    name: "Memorium",
+    name: "Memorial",
     palette: {
         primary: red,
         secondary: red
@@ -140,4 +122,4 @@ export const attractTheme: HyperspaceTheme = {
     }
 }
 
-export const themes = [defaultTheme, gardenerTheme, teacherTheme, jokerTheme, brotherTheme, guardTheme, scientistTheme, entertainerTheme, kingTheme, dragonTheme, memoriumTheme, blissTheme, attractTheme]
+export const themes = [defaultTheme, gardenerTheme, teacherTheme, jokerTheme, guardTheme, entertainerTheme, kingTheme, dragonTheme, memoriumTheme, blissTheme, attractTheme]

--- a/src/types/HyperspaceTheme.tsx
+++ b/src/types/HyperspaceTheme.tsx
@@ -1,5 +1,5 @@
 import {Color} from '@material-ui/core';
-import { deepPurple, red, lightGreen, yellow, purple, deepOrange, indigo, lightBlue, orange, blue, amber, pink, brown } from '@material-ui/core/colors';
+import { deepPurple, red, lightGreen, yellow, purple, deepOrange, indigo, lightBlue, orange, blue, amber, pink, brown, blueGrey } from '@material-ui/core/colors';
 
 /**
  * Basic theme colors for Hyperspace.
@@ -8,8 +8,12 @@ export type HyperspaceTheme = {
     key: string;
     name: string;
     palette: {
-        primary: Color;
-        secondary: Color;
+        primary: {
+            main: string;
+        } | Color;
+        secondary: {
+            main: string;
+        } | Color;
     }
 }
 
@@ -116,9 +120,24 @@ export const blissTheme: HyperspaceTheme = {
     key: "blissTheme",
     name: "Bliss",
     palette: {
-        primary: brown,
+        primary: {
+            main: "#3e2723"
+        },
         secondary: lightBlue
     }
 }
 
-export const themes = [defaultTheme, gardenerTheme, teacherTheme, jokerTheme, brotherTheme, guardTheme, scientistTheme, entertainerTheme, kingTheme, dragonTheme, memoriumTheme, blissTheme]
+export const attractTheme: HyperspaceTheme = {
+    key: "attractTheme",
+    name: "Attract",
+    palette: {
+        primary: {
+            main: '#f5f5f5',
+        },
+        secondary: {
+            main: "#1a237e",
+        }
+    }
+}
+
+export const themes = [defaultTheme, gardenerTheme, teacherTheme, jokerTheme, brotherTheme, guardTheme, scientistTheme, entertainerTheme, kingTheme, dragonTheme, memoriumTheme, blissTheme, attractTheme]

--- a/src/types/HyperspaceTheme.tsx
+++ b/src/types/HyperspaceTheme.tsx
@@ -1,5 +1,5 @@
 import {Color} from '@material-ui/core';
-import { deepPurple, red, lightGreen, yellow, purple, deepOrange, indigo, lightBlue, orange, blue, amber, pink } from '@material-ui/core/colors';
+import { deepPurple, red, lightGreen, yellow, purple, deepOrange, indigo, lightBlue, orange, blue, amber, pink, brown } from '@material-ui/core/colors';
 
 /**
  * Basic theme colors for Hyperspace.
@@ -112,4 +112,13 @@ export const memoriumTheme: HyperspaceTheme = {
     }
 }
 
-export const themes = [defaultTheme, gardenerTheme, teacherTheme, jokerTheme, brotherTheme, guardTheme, scientistTheme, entertainerTheme, kingTheme, dragonTheme, memoriumTheme]
+export const blissTheme: HyperspaceTheme = {
+    key: "blissTheme",
+    name: "Bliss",
+    palette: {
+        primary: brown,
+        secondary: lightBlue
+    }
+}
+
+export const themes = [defaultTheme, gardenerTheme, teacherTheme, jokerTheme, brotherTheme, guardTheme, scientistTheme, entertainerTheme, kingTheme, dragonTheme, memoriumTheme, blissTheme]

--- a/src/types/Visibility.tsx
+++ b/src/types/Visibility.tsx
@@ -2,14 +2,3 @@
  * Types of a post's visibility on Mastodon.
  */
 export type Visibility = "direct" | "private" | "unlisted" | "public";
-
-export function toVisibility(what: string) {
-    let visibilities: Visibility[] = ["direct", "private", "unlisted", "public"];
-    let vis: Visibility = "public";
-    visibilities.forEach((visibility: Visibility) => {
-        if (what == visibility) {
-            vis = visibility;
-        }
-    });
-    return vis;
-}

--- a/src/types/Visibility.tsx
+++ b/src/types/Visibility.tsx
@@ -2,3 +2,14 @@
  * Types of a post's visibility on Mastodon.
  */
 export type Visibility = "direct" | "private" | "unlisted" | "public";
+
+export function toVisibility(what: string) {
+    let visibilities: Visibility[] = ["direct", "private", "unlisted", "public"];
+    let vis: Visibility = "public";
+    visibilities.forEach((visibility: Visibility) => {
+        if (what == visibility) {
+            vis = visibility;
+        }
+    });
+    return vis;
+}

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -2,6 +2,7 @@ import { defaultTheme, themes } from "../types/HyperspaceTheme";
 import { getNotificationRequestPermission } from './notifications';
 import axios from 'axios';
 import { Config } from "../types/Config";
+import { Visibility } from "../types/Visibility";
 
 type SettingsTemplate = {
     [key:string]: any;
@@ -35,6 +36,30 @@ export function setUserDefaultBool(key: string, value: boolean) {
         console.warn('This key has not been set before.');
     }
     localStorage.setItem(key, value.toString());
+}
+
+/**
+ * Gets the user default visibility from localStorage
+ * @returns The Visibility value associated with the key
+ */
+export function getUserDefaultVisibility(): Visibility {
+    if (localStorage.getItem("defaultVisibility") === null) {
+        console.warn('This key has not been set before, so the default value is PUBLIC for now.');
+        return "public";
+    } else {
+        return localStorage.getItem("defaultVisibility") as Visibility;
+    }
+}
+
+/**
+ * Set a user default visibility to localStorage
+ * @param key The settings key in localStorage to change
+ */
+export function setUserDefaultVisibility(key: string) {
+    if (localStorage.getItem("defaultVisibility") === null) {
+        console.warn('This key has not been set before.');
+    }
+    localStorage.setItem("defaultVisibility", key.toString());
 }
 
 /**
@@ -76,7 +101,7 @@ export function createUserDefaults() {
             if (typeof defaults[setting] === "boolean") {
                 setUserDefaultBool(setting, defaults[setting]);
             } else {
-                localStorage.setItem(setting, defaults[setting]);
+                localStorage.setItem(setting, defaults[setting].toString());
             }
 
         }

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -7,9 +7,11 @@ import { Visibility } from "../types/Visibility";
 type SettingsTemplate = {
     [key:string]: any;
     darkModeEnabled: boolean;
+    systemDecidesDarkMode: boolean;
     enablePushNotifications: boolean;
     clearNotificationsOnRead: boolean;
     displayAllOnNotificationBadge: boolean;
+    defaultVisibility: string;
 }
 
 /**
@@ -89,13 +91,14 @@ export function setUserDefaultTheme(themeName: string) {
 export function createUserDefaults() {
     let defaults: SettingsTemplate = {
         darkModeEnabled: false,
+        systemDecidesDarkMode: true,
         enablePushNotifications: true,
         clearNotificationsOnRead: false,
         displayAllOnNotificationBadge: false,
         defaultVisibility: "public"
     }
 
-    let settings = ["darkModeEnabled", "clearNotificationsOnRead", "displayAllOnNotificationBadge", "defaultVisibility"];
+    let settings = ["darkModeEnabled", "systemDecidesDarkMode", "clearNotificationsOnRead", "displayAllOnNotificationBadge", "defaultVisibility"];
     settings.forEach((setting: string) => {
         if (localStorage.getItem(setting) === null) {
             if (typeof defaults[setting] === "boolean") {

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -66,13 +66,19 @@ export function createUserDefaults() {
         darkModeEnabled: false,
         enablePushNotifications: true,
         clearNotificationsOnRead: false,
-        displayAllOnNotificationBadge: false
+        displayAllOnNotificationBadge: false,
+        defaultVisibility: "public"
     }
 
-    let settings = ["darkModeEnabled"];
+    let settings = ["darkModeEnabled", "clearNotificationsOnRead", "displayAllOnNotificationBadge", "defaultVisibility"];
     settings.forEach((setting: string) => {
         if (localStorage.getItem(setting) === null) {
-            setUserDefaultBool(setting, defaults[setting]);
+            if (typeof defaults[setting] === "boolean") {
+                setUserDefaultBool(setting, defaults[setting]);
+            } else {
+                localStorage.setItem(setting, defaults[setting]);
+            }
+
         }
     })
     getNotificationRequestPermission();

--- a/src/utilities/themes.tsx
+++ b/src/utilities/themes.tsx
@@ -42,9 +42,22 @@ export function setHyperspaceTheme(theme: HyperspaceTheme): Theme {
         palette: {
             primary: theme.palette.primary,
             secondary: theme.palette.secondary,
-            type: getUserDefaultBool('darkModeEnabled')? "dark": "light"
+            type: getUserDefaultBool('darkModeEnabled')? "dark": 
+                    getDarkModeFromSystem() === "dark"? "dark": "light"
         }
     })
+}
+
+export function getDarkModeFromSystem(): string {
+    if (getUserDefaultBool('systemDecidesDarkMode')) {
+        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+            return "dark";
+        } else {
+            return "light";
+        }
+    } else {
+        return "light";
+    }
 }
 
 /**

--- a/src/utilities/themes.tsx
+++ b/src/utilities/themes.tsx
@@ -1,6 +1,21 @@
 import { createMuiTheme, Theme } from '@material-ui/core';
-import { HyperspaceTheme } from '../types/HyperspaceTheme';
+import { HyperspaceTheme, themes, defaultTheme } from '../types/HyperspaceTheme';
 import { getUserDefaultBool } from './settings';
+
+/**
+ * Locates a Hyperspace theme from the themes catalog
+ * @param name The name of the theme to return
+ * @returns Hyperspace theme with name or the default
+ */
+export function getHyperspaceTheme(name: string): HyperspaceTheme {
+    let theme: HyperspaceTheme = defaultTheme;
+    themes.forEach((themeItem: HyperspaceTheme) => {
+        if (themeItem.key === name) {
+            theme = themeItem;
+        }
+    });
+    return theme;
+}
 
 /**
  * Creates a Material-UI theme from a selected Hyperspace theme palette.


### PR DESCRIPTION
This PR makes the following changes:

* A new `location` field in the config file should help mitigate redirect URL issues that cause client authentication errors. (#8)
* The notification badge will now be displayed on mobile devices in the menu and should no longer disappear and lose count with the setting "Notification badge counts all notifications'' turned on (fixes #7).
* The theme chooser has been slightly redesigned to include a new theme preview before applying the theme.
* A new setting is available to set the default visibility when composing new posts.
* The drawer menu on mobile devices has been reorganized in a logical manner.
* A new setting that allows the app to follow the browser's/platform's light mode/dark mode preference has been added.
* A few changes have been made to themes in general:
  * The 'Brother' and 'Scientist' themes have been removed.
  * Most existing themes have been renamed.
  * Two new themes, Bliss and Attract, have been added.
* The 'Who to follow' page link has been enabled.
* A new recommendations page is available to follow suggested accounts and manage follow requests.
* A new '404' page has been added.