### PR TITLE
Spruce up login page

### DIFF
--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -297,7 +297,7 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                     {
                         this.state.foundSavedLogin? 
                             <Typography>
-                                Signing in from a previous session? <Link onClick={() => this.resumeLogin()}>Continue login</Link>.
+                                Signing in from a previous session? <Link className={classes.welcomeLink} onClick={() => this.resumeLogin()}>Continue login</Link>.
                             </Typography>: null
                     }
                     
@@ -305,7 +305,6 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                     <div style={{ display: "flex" }}>
                         <Tooltip title="Create account on site">
                             <Button
-                                color="primary"
                                 href={this.startRegistration()}
                                 target="_blank"
                                 rel="noreferrer"
@@ -336,12 +335,12 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                             size="large"
                             href={this.state.authUrl? this.state.authUrl: ""}
                         >
-                            <Typography color="textPrimary" variant="button">Authorize</Typography>
+                            Authorize
                         </Button>
                         <div className={classes.flexGrow}/>
                     </div>
                     <div className={classes.middlePadding}/>
-                    <Typography>Having trouble signing in? <Link onClick={() => this.startEmergencyLogin()}>Sign in with a code.</Link></Typography>
+                    <Typography>Having trouble signing in? <Link onClick={() => this.startEmergencyLogin()} className={classes.welcomeLink}>Sign in with a code.</Link></Typography>
                 </div>
         );
     }
@@ -421,10 +420,13 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                 </Fade>
                 <br/>
                 <Typography variant="caption">
-                    &copy; {new Date().getFullYear()} {this.state.brandName && this.state.brandName !== "Hyperspace"? `${this.state.brandName} developers and the `: ""}<Link href="https://hyperspace.marquiskurt.net" target="_blank" rel="noreferrer">Hyperspace</Link> developers. All rights reserved.
+                    &copy; {new Date().getFullYear()} {this.state.brandName && this.state.brandName !== "Hyperspace"? `${this.state.brandName} developers and the `: ""} <Link className={classes.welcomeLink} href="https://hyperspace.marquiskurt.net" target="_blank" rel="noreferrer">Hyperspace</Link> developers. All rights reserved.
                 </Typography>
                 <Typography variant="caption">
-                { this.state.repo? <span><Link href={this.state.repo? this.state.repo: "https://github.com/hyperspacedev"} target="_blank" rel="noreferrer">Source code</Link>  | </span>: null}<Link href={this.state.license? this.state.license: "https://www.apache.org/licenses/LICENSE-2.0"} target="_blank" rel="noreferrer">License</Link> | <Link href="https://github.com/hyperspacedev/hyperspace/issues/new" target="_blank" rel="noreferrer">File an Issue</Link>
+                { this.state.repo? <span>
+                    <Link className={classes.welcomeLink} href={this.state.repo? this.state.repo: "https://github.com/hyperspacedev"} target="_blank" rel="noreferrer">Source code</Link>  | </span>: null}
+                    <Link className={classes.welcomeLink} href={this.state.license? this.state.license: "https://www.apache.org/licenses/LICENSE-2.0"} target="_blank" rel="noreferrer">License</Link> | 
+                    <Link className={classes.welcomeLink} href="https://github.com/hyperspacedev/hyperspace/issues/new" target="_blank" rel="noreferrer">File an Issue</Link>
                 </Typography>
                 <Typography variant="caption" color="textSecondary">
                     {this.state.brandName? this.state.brandName: "Hypersapce"} v.{this.state.version} {this.state.brandName && this.state.brandName !== "Hyperspace"? "(Hyperspace-like)": null}

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -333,7 +333,7 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                             size="large"
                             href={this.state.authUrl? this.state.authUrl: ""}
                         >
-                            Authorize
+                            <Typography color="textPrimary" variant="button">Authorize</Typography>
                         </Button>
                         <div className={classes.flexGrow}/>
                     </div>

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -34,6 +34,7 @@ interface IWelcomeState {
     openAuthDialog: boolean;
     authCode: string;
     emergencyMode: boolean;
+    version: string;
 }
 
 class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
@@ -53,7 +54,8 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
             defaultRedirectAddress: '',
             openAuthDialog: false,
             authCode: '',
-            emergencyMode: false
+            emergencyMode: false,
+            version: ''
         }
 
         getConfig().then((result: any) => {
@@ -68,7 +70,8 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                 federates: result.federated? result.federated === "true": true,
                 license: result.license.url,
                 repo: result.repository,
-                defaultRedirectAddress: result.location != "dynamic"? result.location: `https://${window.location.host}`
+                defaultRedirectAddress: result.location != "dynamic"? result.location: `https://${window.location.host}`,
+                version: result.version
             });
         }).catch(() => {
             console.error('config.json is missing. If you want to customize Hyperspace, please include config.json');
@@ -276,9 +279,9 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                     <div className={classes.middlePadding}/>
                     <TextField
                         variant="outlined"
-                        label="Account name"
+                        label="Username"
                         fullWidth
-                        placeholder="example@mastodon.host"
+                        placeholder="example@mastodon.example"
                         onChange={(event) => this.updateUserInfo(event.target.value)}
                         error={this.state.userInputError}
                         onBlur={() => this.checkForErrors()}
@@ -288,7 +291,7 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                     }
                     <br/>
                     {
-                        this.state.registerBase? <Typography variant="caption">If you are from <b>{this.state.registerBase? this.state.registerBase: "noinstance"}</b>, sign in with your username.</Typography>: null
+                        this.state.registerBase? <Typography variant="caption">Not from <b>{this.state.registerBase? this.state.registerBase: "noinstance"}</b>? Sign in with your <Link href="https://docs.joinmastodon.org/usage/decentralization/#addressing-people" target="_blank" rel="noopener noreferrer" color="secondary">full username</Link>.</Typography>: null
                     }
                     <br/>
                     {
@@ -422,6 +425,9 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                 </Typography>
                 <Typography variant="caption">
                 { this.state.repo? <span><Link href={this.state.repo? this.state.repo: "https://github.com/hyperspacedev"} target="_blank" rel="noreferrer">Source code</Link>  | </span>: null}<Link href={this.state.license? this.state.license: "https://www.apache.org/licenses/LICENSE-2.0"} target="_blank" rel="noreferrer">License</Link> | <Link href="https://github.com/hyperspacedev/hyperspace/issues/new" target="_blank" rel="noreferrer">File an Issue</Link>
+                </Typography>
+                <Typography variant="caption" color="textSecondary">
+                    {this.state.brandName? this.state.brandName: "Hypersapce"} v.{this.state.version} {this.state.brandName && this.state.brandName !== "Hyperspace"? "(Hyperspace-like)": null}
                 </Typography>
             </Paper>
             {this.showAuthDialog()}

--- a/src/pages/WelcomePage.styles.tsx
+++ b/src/pages/WelcomePage.styles.tsx
@@ -34,9 +34,9 @@ export const styles = (theme: Theme) => createStyles({
         paddingRight: theme.spacing.unit * 4,
         paddingBottom: theme.spacing.unit * 6,
         textAlign: 'center',
-        '& a': {
-            color: theme.palette.primary.light
-        }
+    },
+    welcomeLink: {
+        color: theme.palette.primary.light
     },
     flexGrow: {
         flexGrow: 1


### PR DESCRIPTION
This PR makes the following changes:

* Fixes the issue where the Authorize button on the login page appears ghosted (fixes #24).
* Changes the helper text on landing to _Not from <instance.domain>? Sign in with your full username._ with a link to "Addressing people" from Mastodon docs to assist.
* Adds version text to bottom of login dialog.