### PR TITLE
Update themes and empty text padding CSS

### DIFF
--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -252,7 +252,7 @@ class NotificationsPage extends Component<any, INotificationsPageState> {
                                 </List>
                             </Paper>
                         </div>:
-                        <div>
+                        <div className={classes.pageLayoutEmptyTextConstraints}>
                             <Typography variant="h4">All clear!</Typography>
                             <Typography paragraph>It looks like you have no notifications. Why not get the conversation going with a new post?</Typography>
                         </div>:

--- a/src/pages/PageLayout.styles.tsx
+++ b/src/pages/PageLayout.styles.tsx
@@ -52,6 +52,10 @@ export const styles = (theme: Theme) => createStyles({
         marginLeft: 250,
       },
     },
+    pageLayoutEmptyTextConstraints: {
+      paddingLeft: theme.spacing.unit * 2,
+      paddingRight: theme.spacing.unit * 2
+    },
     pageHeroBackground: {
       position: 'relative',
       height: 'intrinsic',
@@ -174,5 +178,5 @@ export const styles = (theme: Theme) => createStyles({
       '& a': {
         color: theme.palette.primary.light
       }
-    }
+    },
   });

--- a/src/pages/Recommendations.tsx
+++ b/src/pages/Recommendations.tsx
@@ -201,7 +201,7 @@ class RecommendationsPage extends Component<IRecommendationsPageProps, IRecommen
                             {
                                 this.state.requestedFollows && this.state.requestedFollows.length > 0?
                                 this.showFollowRequests():
-                                <div>
+                                <div className={classes.pageLayoutEmptyTextConstraints}>
                                     <Typography variant="h6">You don't have any follow requests.</Typography>
                                     <br/>
                                 </div>
@@ -210,7 +210,7 @@ class RecommendationsPage extends Component<IRecommendationsPageProps, IRecommen
                             <br/>
                             {
                                 this.state.followSuggestions && this.state.followSuggestions.length > 0? this.showFollowSuggestions(): 
-                                <div>
+                                <div className={classes.pageLayoutEmptyTextConstraints}>
                                     <Typography variant="h5">We don't have any suggestions for you.</Typography>
                                     <Typography paragraph>Why not interact with the fediverse a bit by creating a new post?</Typography>
                                 </div>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -164,11 +164,12 @@ class SearchPage extends Component<any, ISearchPageState> {
         return (
             <div>
                 <ListSubheader>Accounts</ListSubheader>
-                    <Paper className={classes.pageListConstraints}>
-                        <List>
+
                             {
-                                this.state.results?
-                                    this.state.results.accounts.map((acct: Account) => {
+                                this.state.results && this.state.results.accounts.length > 0?
+                                <Paper className={classes.pageListConstraints}>
+                                    <List>
+                                        { this.state.results.accounts.map((acct: Account) => {
                                         return (
                                         <ListItem key={acct.id}>
                                             <ListItemAvatar>
@@ -189,16 +190,19 @@ class SearchPage extends Component<any, ISearchPageState> {
                                             </ListItemSecondaryAction>
                                         </ListItem>
                                         );
-                                    }): null
+                                    })}
+                                    </List>
+                                </Paper>: <Typography variant="caption" className={classes.pageLayoutEmptyTextConstraints}>No results found</Typography>
                             }
-                        </List>
-                    </Paper>
+                            
+
                 <br/>
             </div>
         )
     }
 
     showAllPostsFromQuery() {
+        const {classes} = this.props;
         return (
             <div>
                 <ListSubheader>Posts</ListSubheader>
@@ -207,13 +211,14 @@ class SearchPage extends Component<any, ISearchPageState> {
                             this.state.results.statuses.length > 0?
                                 this.state.results.statuses.map((post: Status) => {
                                     return <Post key={post.id} post={post} client={this.client}/>
-                                }): <Typography variant="caption">No results found.</Typography>: null
+                                }): <Typography variant="caption" className={classes.pageLayoutEmptyTextConstraints}>No results found.</Typography>: null
                     }
             </div>
         );
     }
 
     showAllPostsWithTag() {
+        const {classes} = this.props;
         return (
             <div>
                 <ListSubheader>Tagged posts</ListSubheader>
@@ -222,7 +227,7 @@ class SearchPage extends Component<any, ISearchPageState> {
                             this.state.tagResults.length > 0?
                                 this.state.tagResults.map((post: Status) => {
                                     return <Post key={post.id} post={post} client={this.client}/>
-                                }): <Typography variant="caption">No results found.</Typography>: null
+                                }): <Typography variant="caption" className={classes.pageLayoutEmptyTextConstraints}>No results found.</Typography>: null
                     }
             </div>
         );

--- a/src/types/HyperspaceTheme.tsx
+++ b/src/types/HyperspaceTheme.tsx
@@ -71,12 +71,16 @@ export const entertainerTheme: HyperspaceTheme = {
     }
 }
 
-export const kingTheme: HyperspaceTheme = {
-    key: "kingTheme",
-    name: "Royal II",
+export const classicTheme: HyperspaceTheme = {
+    key: "classicTheme",
+    name: "Classic",
     palette: {
-        primary: deepPurple,
-        secondary: amber
+        primary: {
+            main: "#555555"
+        },
+        secondary: {
+            main: "#5c2d91"
+        }
     }
 }
 
@@ -122,4 +126,4 @@ export const attractTheme: HyperspaceTheme = {
     }
 }
 
-export const themes = [defaultTheme, gardenerTheme, teacherTheme, jokerTheme, guardTheme, entertainerTheme, kingTheme, dragonTheme, memoriumTheme, blissTheme, attractTheme]
+export const themes = [defaultTheme, gardenerTheme, teacherTheme, jokerTheme, guardTheme, entertainerTheme, classicTheme, dragonTheme, memoriumTheme, blissTheme, attractTheme]

--- a/src/types/HyperspaceTheme.tsx
+++ b/src/types/HyperspaceTheme.tsx
@@ -114,10 +114,10 @@ export const attractTheme: HyperspaceTheme = {
     name: "Attract",
     palette: {
         primary: {
-            main: '#f5f5f5',
+            main: '#E57373',
         },
         secondary: {
-            main: "#1a237e",
+            main: "#78909C",
         }
     }
 }


### PR DESCRIPTION
This PR makes the following changes: 

- Changes the Attract theme colors to prevent CSS collisions with existing Material-UI components (fixes #26).
- Adds an `pageLayoutEmptyTextConstraints` CSS class to PageLayout styles (fixes #27).
- Updates the search query on accounts so that "No results found" is displayed instead of empty paper.
- Removed the King theme and replaced with the Classic theme.

## New Attract theme
<img width="949" alt="Screen Shot 2019-04-27 at 12 35 24" src="https://user-images.githubusercontent.com/13445064/56852551-bdf38580-68ea-11e9-8aeb-5103bc2ee05e.png">

## New Classic Theme
<img width="949" alt="Screen Shot 2019-04-27 at 12 35 17" src="https://user-images.githubusercontent.com/13445064/56852542-aa481f00-68ea-11e9-8dfc-433af5cbcc56.png">