### PR TITLE
More control on defederation settings

### DIFF
--- a/src/pages/Compose.tsx
+++ b/src/pages/Compose.tsx
@@ -20,7 +20,7 @@ import ComposeMediaAttachment from '../components/ComposeMediaAttachment';
 import EmojiPicker from '../components/EmojiPicker';
 import { DateTimePicker, MuiPickersUtilsProvider } from 'material-ui-pickers';
 import MomentUtils from '@date-io/moment';
-import { getUserDefaultVisibility } from '../utilities/settings';
+import { getUserDefaultVisibility, getConfig } from '../utilities/settings';
 
 interface IComposerState {
     account: UAccount;
@@ -36,6 +36,7 @@ interface IComposerState {
     poll?: PollWizard;
     pollExpiresDate?: any;
     showEmojis: boolean;
+    federated: boolean;
 }
 
 class Composer extends Component<any, IComposerState> {
@@ -54,20 +55,26 @@ class Composer extends Component<any, IComposerState> {
             visibilityMenu: false,
             text: '',
             remainingChars: 500,
-            showEmojis: false
+            showEmojis: false,
+            federated: true
         }
     }
 
     componentDidMount() {
         let state = this.getComposerParams(this.props);
         let text = state.acct? `@${state.acct}: `: '';
-        this.setState({
-            reply: state.reply,
-            acct: state.acct,
-            visibility: state.visibility,
-            text,
-            remainingChars: 500 - text.length
+        getConfig().then((config: any) => {
+            this.setState({ 
+                federated: config.federated === "true",
+                reply: state.reply,
+                acct: state.acct,
+                visibility: state.visibility,
+                text,
+                remainingChars: 500 - text.length
+            });
         })
+        
+
     }
 
     componentWillReceiveProps(props: any) {
@@ -499,7 +506,7 @@ class Composer extends Component<any, IComposerState> {
                         <MenuItem onClick={() => this.changeVisibility('direct')}>Direct (direct message)</MenuItem>
                         <MenuItem onClick={() => this.changeVisibility('private')}>Private (followers only)</MenuItem>
                         <MenuItem onClick={() => this.changeVisibility('unlisted')}>Unlisted</MenuItem>
-                        <MenuItem onClick={() => this.changeVisibility('public')}>Public</MenuItem>
+                        {this.state.federated? <MenuItem onClick={() => this.changeVisibility('public')}>Public</MenuItem>: null}
                     </Menu>
                 </Toolbar>
                 <DialogActions>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -24,7 +24,7 @@ import {
 } from '@material-ui/core';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import {styles} from './PageLayout.styles';
-import {setUserDefaultBool, getUserDefaultBool, getUserDefaultTheme, setUserDefaultTheme, getUserDefaultVisibility, setUserDefaultVisibility} from '../utilities/settings';
+import {setUserDefaultBool, getUserDefaultBool, getUserDefaultTheme, setUserDefaultTheme, getUserDefaultVisibility, setUserDefaultVisibility, getConfig} from '../utilities/settings';
 import {canSendNotifications, browserSupportsNotificationRequests} from '../utilities/notifications';
 import {themes, defaultTheme} from '../types/HyperspaceTheme';
 import ThemePreview from '../components/ThemePreview';
@@ -43,6 +43,7 @@ interface ISettingsState {
     resetSettingsDialog: boolean;
     previewTheme: Theme;
     defaultVisibility: Visibility;
+    federated: boolean;
 }
 
 class SettingsPage extends Component<any, ISettingsState> {
@@ -61,7 +62,8 @@ class SettingsPage extends Component<any, ISettingsState> {
             resetHyperspaceDialog: false,
             resetSettingsDialog: false,
             previewTheme: setHyperspaceTheme(getUserDefaultTheme()) || setHyperspaceTheme(defaultTheme),
-            defaultVisibility: getUserDefaultVisibility() || "public"
+            defaultVisibility: getUserDefaultVisibility() || "public",
+            federated: true
         }
 
         this.toggleDarkMode = this.toggleDarkMode.bind(this);
@@ -73,6 +75,16 @@ class SettingsPage extends Component<any, ISettingsState> {
         this.changeThemeName = this.changeThemeName.bind(this);
         this.changeTheme = this.changeTheme.bind(this);
         this.setVisibility = this.setVisibility.bind(this);
+    }
+
+    componentDidMount() {
+        this.getFederatedStatus();
+    }
+
+    getFederatedStatus() {
+        getConfig().then((config: any) => {
+            this.setState({ federated: config.federated === "true" });
+        })
     }
 
     toggleDarkMode() {
@@ -208,7 +220,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                         value={this.state.defaultVisibility}
                         onChange={(e, value) => this.changeVisibility(value as Visibility)}
                     >
-                            <FormControlLabel value={"public"} key={"public"} control={<Radio />} label={"Public"} />
+                            <FormControlLabel value={"public"} key={"public"} control={<Radio />} label={`Public ${this.state.federated? "": "(disabled by provider)"}`} disabled={!this.state.federated}/>
                             <FormControlLabel value={"unlisted"} key={"unlisted"} control={<Radio />} label={"Unlisted"} />
                             <FormControlLabel value={"private"} key={"private"} control={<Radio />} label={"Private (followers only)"} />
                             <FormControlLabel value={"direct"} key={"direct"} control={<Radio />} label={"Direct"} />

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -302,7 +302,7 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                     }
                     <br/>
                     {
-                        this.state.registerBase? <Typography variant="caption">Not from <b>{this.state.registerBase? this.state.registerBase: "noinstance"}</b>? Sign in with your <Link href="https://docs.joinmastodon.org/usage/decentralization/#addressing-people" target="_blank" rel="noopener noreferrer" color="secondary">full username</Link>.</Typography>: null
+                        this.state.registerBase && this.state.federates? <Typography variant="caption">Not from <b>{this.state.registerBase? this.state.registerBase: "noinstance"}</b>? Sign in with your <Link href="https://docs.joinmastodon.org/usage/decentralization/#addressing-people" target="_blank" rel="noopener noreferrer" color="secondary">full username</Link>.</Typography>: null
                     }
                     <br/>
                     {

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -134,7 +134,7 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
     }
 
     getLoginUser(user: string) {
-        if (user.includes("@")) {
+        if (this.state.federates || user.includes("@")) {
             let newUser = user;
             this.setState({ user: newUser })
             return "https://" + newUser.split("@")[1];
@@ -222,17 +222,28 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
             return true;
         } else {
             if (this.state.user.includes("@")) {
-                let baseUrl = this.state.user.split("@")[1];
-                axios.get("https://" + baseUrl + "/api/v1/timelines/public").catch((err: Error) => {
-                    let userInputError = true;
-                    let userInputErrorMessage = "Instance name is invalid.";
+                if (this.state.federates && (this.state.federates === true)) {
+                    let baseUrl = this.state.user.split("@")[1];
+                    axios.get("https://" + baseUrl + "/api/v1/timelines/public").catch((err: Error) => {
+                        let userInputError = true;
+                        let userInputErrorMessage = "Instance name is invalid.";
+                        this.setState({ userInputError, userInputErrorMessage });
+                        return true;
+                    });
+                } else if (this.state.user.includes(this.state.registerBase? this.state.registerBase: "mastodon.social")) {
+                    this.setState({ userInputError, userInputErrorMessage });
+                    return false;
+                } else {
+                    userInputError = true;
+                    userInputErrorMessage = "You cannot sign in with this username.";
                     this.setState({ userInputError, userInputErrorMessage });
                     return true;
-                })
+                }
             } else {
                 this.setState({ userInputError, userInputErrorMessage });
                 return false;
             }
+            this.setState({ userInputError, userInputErrorMessage });
             return false;
         }
         


### PR DESCRIPTION
This PS makes the following changes (fixes #28):

* Disables public visibility on compose window and in settings
* Tightens/strict checks on username input when logging in, only allowing login to the instance listed in `config.json`
* Hides "Not from <instance name>?" text when defederated