### PR TITLE
Fix #34

### DIFF
--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -177,10 +177,10 @@ export class AppLayout extends Component<any, IAppLayoutState> {
               <Typography className={classes.titleBarText}>Careful: you're running in developer mode.</Typography>
             </div>
           );
-        } else if ((navigator.userAgent.includes("Hyperspace") || navigator.userAgent.includes("Electron")) && navigator.userAgent.includes("Macintosh")) {
+        } else if ((navigator.userAgent.includes(this.state.brandName || "Hyperspace") || navigator.userAgent.includes("Electron")) && navigator.userAgent.includes("Macintosh")) {
           return (
             <div className={classes.titleBarRoot}>
-              <Typography className={classes.titleBarText}>Hyperspace</Typography>
+              <Typography className={classes.titleBarText}>{this.state.brandName? this.state.brandName: "Hyperspace"}</Typography>
             </div>
           );
         }
@@ -376,10 +376,10 @@ export class AppLayout extends Component<any, IAppLayoutState> {
           open={this.state.logOutOpen}
           onClose={() => this.toggleLogOutDialog()}
           >
-          <DialogTitle id="alert-dialog-title">Log out of Hyperspace?</DialogTitle>
+          <DialogTitle id="alert-dialog-title">Log out of {this.state.brandName? this.state.brandName: "Hyperspace"}</DialogTitle>
           <DialogContent>
               <DialogContentText id="alert-dialog-description">
-                You'll need to remove Hyperspace from your list of authorized apps and log in again if you want to use Hyperspace.
+                You'll need to remove {this.state.brandName? this.state.brandName: "Hyperspace"} from your list of authorized apps and log in again if you want to use {this.state.brandName? this.state.brandName: "Hyperspace"}.
               </DialogContentText>
           </DialogContent>
           <DialogActions>

--- a/src/interfaces/Config.tsx
+++ b/src/interfaces/Config.tsx
@@ -1,0 +1,22 @@
+import {License} from '../types/Config';
+
+export interface Config {
+    version: string;
+    location: string;
+    branding?: {
+        name?: string;
+        logo?: string;
+        background?: string;
+    };
+    developer?: string;
+    federated?: string;
+    registration?: {
+        defaultInstance?: string;
+    };
+    admin?: {
+        name?: string;
+        account?: string;
+    };
+    license: License;
+    respository?: string;
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -24,7 +24,7 @@ import {
 } from '@material-ui/core';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import {styles} from './PageLayout.styles';
-import {setUserDefaultBool, getUserDefaultBool, getUserDefaultTheme, setUserDefaultTheme, getUserDefaultVisibility, setUserDefaultVisibility} from '../utilities/settings';
+import {setUserDefaultBool, getUserDefaultBool, getUserDefaultTheme, setUserDefaultTheme, getUserDefaultVisibility, setUserDefaultVisibility, getConfig} from '../utilities/settings';
 import {canSendNotifications, browserSupportsNotificationRequests} from '../utilities/notifications';
 import {themes, defaultTheme} from '../types/HyperspaceTheme';
 import ThemePreview from '../components/ThemePreview';
@@ -43,6 +43,7 @@ interface ISettingsState {
     resetSettingsDialog: boolean;
     previewTheme: Theme;
     defaultVisibility: Visibility;
+    brandName: string;
 }
 
 class SettingsPage extends Component<any, ISettingsState> {
@@ -61,7 +62,8 @@ class SettingsPage extends Component<any, ISettingsState> {
             resetHyperspaceDialog: false,
             resetSettingsDialog: false,
             previewTheme: setHyperspaceTheme(getUserDefaultTheme()) || setHyperspaceTheme(defaultTheme),
-            defaultVisibility: getUserDefaultVisibility() || "public"
+            defaultVisibility: getUserDefaultVisibility() || "public",
+            brandName: "Hyperspace"
         }
 
         this.toggleDarkMode = this.toggleDarkMode.bind(this);
@@ -73,6 +75,16 @@ class SettingsPage extends Component<any, ISettingsState> {
         this.changeThemeName = this.changeThemeName.bind(this);
         this.changeTheme = this.changeTheme.bind(this);
         this.setVisibility = this.setVisibility.bind(this);
+    }
+
+    componentDidMount() {
+        getConfig().then((config: any) => {
+            this.setState({
+                brandName: config.branding.name
+            })
+        }).catch((err: Error) => {
+            console.error(err.message);
+        })
     }
 
     toggleDarkMode() {
@@ -253,10 +265,10 @@ class SettingsPage extends Component<any, ISettingsState> {
                 open={this.state.resetHyperspaceDialog}
                 onClose={() => this.toggleResetDialog()}
                 >
-                <DialogTitle id="alert-dialog-title">Reset Hyperspace?</DialogTitle>
+                <DialogTitle id="alert-dialog-title">Reset {this.state.brandName}?</DialogTitle>
                 <DialogContent>
                     <DialogContentText id="alert-dialog-description">
-                        Are you sure you want to reset Hyperspace? You'll need to sign in again and grant Hyperspace access to use it again.
+                        Are you sure you want to reset {this.state.brandName}? You'll need to re-authorize {this.state.brandName} access again.
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>
@@ -389,7 +401,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                             </ListItemSecondaryAction>
                         </ListItem>
                         <ListItem>
-                            <ListItemText primary="Reset Hyperspace" secondary="Deletes all data and resets the app"/>
+                            <ListItemText primary={`Reset ${this.state.brandName}`} secondary="Deletes all data and resets the app"/>
                             <ListItemSecondaryAction>
                                 <Button onClick={() => this.toggleResetDialog()}>
                                     Reset

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -151,7 +151,12 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
             const scopes = 'read write follow';
             const baseurl = this.getLoginUser(this.state.user);
             localStorage.setItem("baseurl", baseurl);
-            createHyperspaceApp(scopes, baseurl, this.state.defaultRedirectAddress).then((resp: any) => {
+            createHyperspaceApp(
+                this.state.brandName? this.state.brandName: "Hyperspace", 
+                scopes, 
+                baseurl, 
+                this.state.defaultRedirectAddress
+            ).then((resp: any) => {
                 let saveSessionForCrashing: SaveClientSession = {
                     clientId: resp.clientId,
                     clientSecret: resp.clientSecret,
@@ -175,9 +180,13 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
         console.log("Creating an emergency login...")
         const scopes = "read write follow";
         const baseurl = localStorage.getItem('baseurl') || this.getLoginUser(this.state.user);
-        Mastodon.registerApp(this.state.brandName? this.state.brandName: "Hyperspace", {
-            scopes: scopes
-        }, baseurl).then((appData: any) => {
+        Mastodon.registerApp(
+            this.state.brandName? this.state.brandName: "Hyperspace", 
+            {
+                scopes: scopes
+            }, 
+            baseurl
+        ).then((appData: any) => {
             let saveSessionForCrashing: SaveClientSession = {
                 clientId: appData.clientId,
                 clientSecret: appData.clientSecret,
@@ -260,7 +269,7 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                     localStorage.setItem("access_token", tokenData.access_token);
                     window.location.href=`https://${window.location.host}/#/`;
                 }).catch((err: Error) => {
-                    this.props.enqueueSnackbar("Couldn't authorize Hyperspace: " + err.name, {variant: 'error'});
+                    this.props.enqueueSnackbar(`Couldn't authorize ${this.state.brandName? this.state.brandName: "Hyperspace"}: ${err.name}`, {variant: 'error'});
                     console.error(err.message);
                 })
             }
@@ -323,7 +332,7 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
         return (
                 <div>
                     <Typography variant="h5">Howdy, {this.state.user? this.state.user.split("@")[0]: "user"}</Typography>
-                    <Typography>To continue, finish signing in on your instance's website and authorize Hyperspace.</Typography>
+                    <Typography>To continue, finish signing in on your instance's website and authorize {this.state.brandName? this.state.brandName: "Hyperspace"}.</Typography>
                     <div className={classes.middlePadding}/>
                     <div style={{ display: "flex" }}>
                         <div className={classes.flexGrow}/>

--- a/src/utilities/login.tsx
+++ b/src/utilities/login.tsx
@@ -2,12 +2,14 @@ import Mastodon from 'megalodon';
 
 /**
  * Creates the Hyperspace app with the appropriate Redirect URI
+ * @param name The name of the app (if not Hyperspace, will use `name (Hyperspace-like)`)
  * @param scopes The scopes that the app needs
  * @param baseurl The base URL of the instance
  * @param redirect_uri The URL to redirect to when authorizing
  */
-export function createHyperspaceApp(scopes: string, baseurl: string, redirect_uri: string) {
-    return Mastodon.createApp("Hyperspace", {
+export function createHyperspaceApp(name: string, scopes: string, baseurl: string, redirect_uri: string) {
+    let appName = name === "Hyperspace"? "Hyperspace": `${name} (Hyperspace-like)`
+    return Mastodon.createApp(appName, {
         scopes: scopes,
         redirect_uris: redirect_uri,
         website: 'https://hyperspace.marquiskurt.net',


### PR DESCRIPTION
This PR makes the following changes:

* Adds name to Settings state and replaces with brand name
* Updates `createHyperspaceApp` to include the name as a parameter (and appends "(Hyperspace-like)" if the name doesn't match "Hyperspace")
* Updates more places that should use brand name in Welcome page
* Fixes #34 