### PR TITLE
Fix well-known login caused by faulty check in federation status

### DIFF
--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -137,10 +137,16 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
     }
 
     getLoginUser(user: string) {
-        if (this.state.federates || user.includes("@")) {
-            let newUser = user;
-            this.setState({ user: newUser })
-            return "https://" + newUser.split("@")[1];
+        if (user.includes("@")) {
+            if (this.state.federates) {
+                let newUser = user;
+                this.setState({ user: newUser });
+                return "https://" + newUser.split("@")[1];
+            } else {
+                let newUser = `${user}@${this.state.registerBase? this.state.registerBase: "mastodon.social"}`;
+                this.setState({ user: newUser });
+                return "https://" + (this.state.registerBase? this.state.registerBase: "mastodon.social");
+            }
         } else {
             let newUser = `${user}@${this.state.registerBase? this.state.registerBase: "mastodon.social"}`;
             this.setState({ user: newUser });


### PR DESCRIPTION
This PR makes the following changes:

* Fixes the well-known login that failed to work due to a faulty check in determining federation status from `config.json`.