### PR TITLE
App info redesigned

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -12,18 +12,23 @@ import {
     withStyles, 
     Typography,
     Link,
-    Tooltip
+    Tooltip,
+    Button
 } from '@material-ui/core';
+
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
-import DomainIcon from '@material-ui/icons/Domain';
 import ChatIcon from '@material-ui/icons/Chat';
 import PersonIcon from '@material-ui/icons/Person';
+import AssignmentIcon from '@material-ui/icons/Assignment';
 import AssignmentIndIcon from '@material-ui/icons/AssignmentInd';
 import NetworkCheckIcon from '@material-ui/icons/NetworkCheck';
 import UpdateIcon from '@material-ui/icons/Update';
 import InfoIcon from '@material-ui/icons/Info';
 import NotesIcon from '@material-ui/icons/Notes';
 import CodeIcon from '@material-ui/icons/Code';
+import TicketAccountIcon from 'mdi-material-ui/TicketAccount';
+import MastodonIcon from 'mdi-material-ui/Mastodon';
+
 import {styles} from './PageLayout.styles';
 import {Instance} from '../types/Instance';
 import {LinkableIconButton, LinkableAvatar} from '../interfaces/overrides';
@@ -33,7 +38,7 @@ import { getConfig } from '../utilities/settings';
 import { License } from '../types/Config';
 
 interface IAboutPageState  {
-    instance?: Instance | any;
+    instance?: Instance;
     federated?: boolean;
     developer?: boolean;
     hyperspaceAdmin?: UAccount;
@@ -64,7 +69,7 @@ class AboutPage extends Component<any, IAboutPageState> {
     componentWillMount() {
         this.client.get('/instance').then((resp: any) => {
             this.setState({
-                instance: resp.data
+                instance: resp.data as Instance
             })
         })
 
@@ -95,24 +100,19 @@ class AboutPage extends Component<any, IAboutPageState> {
         const { classes } = this.props;
         return (
             <div className={classes.pageLayoutConstraints}>
-                <ListSubheader>About your instance</ListSubheader>
-                <Paper className={classes.pageListConstraints}>
-                    <List>
-                        <ListItem>
-                            <ListItemAvatar>
-                                <Avatar>
-                                    <DomainIcon/>
-                                </Avatar>
-                            </ListItemAvatar>
-                            <ListItemText primary="Instance location (URL)" secondary={this.state.instance ? this.state.instance.uri: "Loading..."}/>
-                            <ListItemSecondaryAction>
-                                <Tooltip title="Open in browser">
-                                    <IconButton href={localStorage.getItem("baseurl") as string} target="_blank" rel="noreferrer">
-                                        <OpenInNewIcon/>
-                                    </IconButton>
-                                </Tooltip>
-                            </ListItemSecondaryAction>
-                        </ListItem>
+                <Paper>
+                    <div 
+                        className={classes.instanceHeaderPaper}
+                        style={{
+                            backgroundImage: `url("${this.state.instance && this.state.instance.thumbnail? this.state.instance.thumbnail: ""}")`
+                        }}
+                    >
+                        <IconButton className={classes.instanceToolbar} href={localStorage.getItem("baseurl") as string} target="_blank" rel="noreferrer" color="inherit">
+                            <OpenInNewIcon/>
+                        </IconButton>
+                        <Typography className={classes.instanceHeaderText} variant="h4" component="p">{this.state.instance ? this.state.instance.uri: "Loading..."}</Typography>
+                    </div>
+                    <List className={classes.pageListConstraints}>
                         <ListItem>
                             <ListItemAvatar>
                                 <LinkableAvatar to={`/profile/${this.state.instance? this.state.instance.contact_account.id: 0}`} alt="Instance admin" src={this.state.instance? this.state.instance.contact_account.avatar_static: ""}/>
@@ -133,6 +133,53 @@ class AboutPage extends Component<any, IAboutPageState> {
                                     </LinkableIconButton>
                                 </Tooltip>
                             </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <AssignmentIcon/>
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Terms of service"
+                                secondary="View the rules and privacy policies"
+                            />
+                            <ListItemSecondaryAction>
+                                <Tooltip title="Open in browser">
+                                    <IconButton href={localStorage.getItem("baseurl") as string + "/terms"} target="_blank" rel="noreferrer">
+                                        <OpenInNewIcon/>
+                                    </IconButton>
+                                </Tooltip>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <TicketAccountIcon/>
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Invite a friend"
+                                secondary="Invite a friend to this instance"
+                            />
+                            <ListItemSecondaryAction>
+                                <Tooltip title="Go to invite settings">
+                                    <Button href={localStorage.getItem("baseurl") as string + "/invites"} target="_blank" rel="noreferrer">
+                                        Invite
+                                    </Button>
+                                </Tooltip>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <MastodonIcon/>
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Mastodon version"
+                                secondary={this.state.instance? this.state.instance.version: "x.x.x"}
+                            />
                         </ListItem>
                     </List>
                 </Paper>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -45,6 +45,7 @@ interface IAboutPageState  {
     hyperspaceAdminName?: string;
     versionNumber?: string;
     brandName?: string;
+    brandBg?: string;
     license: License;
     repository?: string;
 }
@@ -76,7 +77,6 @@ class AboutPage extends Component<any, IAboutPageState> {
         getConfig().then((config: any) => {
             this.client.get('/accounts/' + (config.admin? config.admin.account: "0")).then((resp: any) => {
                 let account = resp.data;
-                console.log(config);
                 this.setState({
                     hyperspaceAdmin: account,
                     hyperspaceAdminName: config.admin.name,
@@ -84,6 +84,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                     developer: config.developer? config.developer === "true": false,
                     versionNumber: config.version,
                     brandName: config.branding? config.branding.name: "Hyperspace",
+                    brandBg: config.branding.background,
                     license: {
                         name: config.license.name,
                         url: config.license.url
@@ -183,62 +184,31 @@ class AboutPage extends Component<any, IAboutPageState> {
                         </ListItem>
                     </List>
                 </Paper>
+                
                 <br/>
-                <ListSubheader>About this app</ListSubheader>
-                <Paper className={classes.pageListConstraints}>
-                    <List>
-                        <ListItem>
-                            <ListItemAvatar>
-                                <Avatar>
-                                    <InfoIcon/>
-                                </Avatar>
-                            </ListItemAvatar>
-                            <ListItemText primary="App version" secondary={`${this.state? this.state.brandName: "Hyperspace"} v${this.state? this.state.versionNumber: "1.0.x"} ${this.state && this.state.brandName !== "Hyperspace"? "(Hyperspace-like)": ""}`}/>
-                        </ListItem>
-                        <ListItem>
-                            <ListItemAvatar>
-                                <Avatar>
-                                    <NotesIcon/>
-                                </Avatar>
-                            </ListItemAvatar>
-                            <ListItemText primary="License" secondary={this.state.license.name}/>
-                            <ListItemSecondaryAction>
-                                <Tooltip title = "View license">
-                                    <IconButton href={this.state.license.url} target="_blank" rel="noreferrer">
-                                        <OpenInNewIcon/>
-                                    </IconButton>
-                                </Tooltip>
-                            </ListItemSecondaryAction>
-                        </ListItem>
-                        {
-                            this.state.repository?
-                            <ListItem>
-                                <ListItemAvatar>
-                                    <Avatar>
+
+                <Paper>
+                    <div 
+                        className={classes.instanceHeaderPaper}
+                        style={{
+                            backgroundImage: `url("${this.state.brandBg? this.state.brandBg: ""}")`
+                        }}
+                    >
+                        <div className={classes.instanceToolbar}>
+                            {
+                                this.state.repository?
+                                <Tooltip title="View source code">
+                                    <IconButton href={this.state.repository} target="_blank" rel="noreferrer" color="inherit">
                                         <CodeIcon/>
-                                    </Avatar>
-                                </ListItemAvatar>
-                                <ListItemText primary="Source code repository" secondary={this.state.repository? 
-                                    <span>
-                                        <Typography className={classes.mobileOnly} color='textSecondary'>{this.state.repository.slice(0, 25) + "..."}</Typography>
-                                        <Typography className={classes.desktopOnly} color='textSecondary'>{this.state.repository}</Typography>
-                                    </span>: 
-                                    "No repository in config"}/>
-                                <ListItemSecondaryAction>
-                                    <Tooltip title="View source code">
-                                        <IconButton href={this.state.repository? this.state.repository: ""} target="_blank" rel="noreferrer">
-                                            <OpenInNewIcon/>
-                                        </IconButton>
-                                    </Tooltip>
-                                </ListItemSecondaryAction>
-                            </ListItem>: null
-                        }
-                    </List>
-                </Paper>
-                <br/>
-                <ListSubheader>Advanced app info</ListSubheader>
-                <Paper className={classes.pageListConstraints}>
-                    <List>
+                                    </IconButton>
+                                </Tooltip>: null
+                            }
+                        </div>
+                        <Typography className={classes.instanceHeaderText} variant="h4" component="p">
+                            {this.state.brandName? this.state.brandName: "Hyperspace"}
+                        </Typography>
+                    </div>
+                    <List className={classes.pageListConstraints}>
                         <ListItem>
                             <ListItemAvatar>
                                 <LinkableAvatar to={`/profile/${this.state.hyperspaceAdmin? this.state.hyperspaceAdmin.id: 0}`} src={this.state.hyperspaceAdmin? this.state.hyperspaceAdmin.avatar_static: ""}>
@@ -262,10 +232,17 @@ class AboutPage extends Component<any, IAboutPageState> {
                         <ListItem>
                             <ListItemAvatar>
                                 <Avatar>
-                                    <NetworkCheckIcon/>
+                                    <NotesIcon/>
                                 </Avatar>
                             </ListItemAvatar>
-                            <ListItemText primary="Federation status" secondary={`This instance of ${this.state? this.state.brandName: "Hyperspace"} ${this.state? this.state.federated? "supports": "doesn't support": "might support"} federation.`}/>
+                            <ListItemText primary="License" secondary={this.state.license.name}/>
+                            <ListItemSecondaryAction>
+                                <Tooltip title = "View license">
+                                    <IconButton href={this.state.license.url} target="_blank" rel="noreferrer">
+                                        <OpenInNewIcon/>
+                                    </IconButton>
+                                </Tooltip>
+                            </ListItemSecondaryAction>
                         </ListItem>
                         <ListItem>
                             <ListItemAvatar>
@@ -280,6 +257,28 @@ class AboutPage extends Component<any, IAboutPageState> {
                                         "Release":
                                 "Loading..."
                             }/>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <InfoIcon/>
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary="App version" secondary={`${this.state? this.state.brandName: "Hyperspace"} v${this.state? this.state.versionNumber: "1.0.x"} ${this.state && this.state.brandName !== "Hyperspace"? "(Hyperspace-like)": ""}`}/>
+                        </ListItem>
+                    </List>
+                </Paper>
+                <br/>
+                <ListSubheader>Federation status</ListSubheader>
+                <Paper>
+                    <List className={classes.pageListConstraints}>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <NetworkCheckIcon/>
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary="Federation status" secondary={`This instance of ${this.state? this.state.brandName: "Hyperspace"} ${this.state? this.state.federated? "supports": "doesn't support": "might support"} federation.`}/>
                         </ListItem>
                     </List>
                 </Paper>

--- a/src/pages/PageLayout.styles.tsx
+++ b/src/pages/PageLayout.styles.tsx
@@ -207,4 +207,28 @@ export const styles = (theme: Theme) => createStyles({
       width: 'auto',
       height: 128
     },
+    instanceHeaderPaper: {
+      height: 200,
+      backgroundPosition: "center",
+      backgroundRepeat: "no-repeat",
+      backgroundSize: "cover",
+      position: "relative",
+      backgroundColor: theme.palette.primary.dark,
+      borderTopLeftRadius: theme.shape.borderRadius,
+      borderTopRightRadius: theme.shape.borderRadius
+    },
+    instanceHeaderText: {
+      position: "absolute",
+      bottom: theme.spacing.unit,
+      left: theme.spacing.unit * 2,
+      color: theme.palette.common.white,
+      textShadow: `0 0 4px ${theme.palette.grey[700]}`,
+      fontWeight: 600
+    },
+    instanceToolbar: {
+      position: "absolute",
+      top: theme.spacing.unit,
+      right: theme.spacing.unit,
+      color: theme.palette.common.white
+    }
   });


### PR DESCRIPTION
This PR makes the following changes:

- Introduces new redesign for app info, matching #48 
- Federation set to own category (to display specifics later)

<img width="1552" alt="Screen Shot 2019-05-06 at 15 39 41" src="https://user-images.githubusercontent.com/13445064/57250429-6c977480-7015-11e9-96f8-2c0e3de31211.png">
