### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/hyperspacedev/26fd9a08-0a5d-43b4-a77c-977c58a5430d/167cc8a4-3910-4671-85e3-fa8987ce36f5/_apis/work/boardbadge/3cb6ac2b-e6be-4a76-a0d2-c9e7bdd179e7)](https://dev.azure.com/hyperspacedev/26fd9a08-0a5d-43b4-a77c-977c58a5430d/_boards/board/t/167cc8a4-3910-4671-85e3-fa8987ce36f5/Microsoft.RequirementCategory)
 # Hyperspace v1.0
 
 The new beautiful, fluffy client for Mastodon written in TypeScript and React


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hyperspacedev/26fd9a08-0a5d-43b4-a77c-977c58a5430d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.