### PR TITLE
Add Patreon contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ The built files will be available under `dist` that can be uploaded to your app 
 
 Contrubition guidelines are available in the [contributing file](.github/contributing.md) and when you make an issue/pull request. Additionally, you can access our [Code of Conduct](.github/code_of_conduct.md).
 
-If you want to aid the project in other ways, consider supporting the project on [Patreon](https://patreon.com/marquiskurt).
+If you want to aid the project in other ways, consider supporting the project on [Patreon](https://patreon.com/marquiskurt). You can also [view all of our contributors](patreon.md) that help make Hyperspace possible.
 
 If you have Matrix, you can join the Hyperspace community ([+hyperspace-masto:matrix.org](https://matrix.to/#/+hyperspace-masto:matrix.org)).

--- a/patreon.md
+++ b/patreon.md
@@ -1,0 +1,7 @@
+# Patreon Contributors List
+
+Hyperspace has been made possible by the efforts of the Hyperspace development team and these amazing contributors on Patreon:
+
+- LucasAzazer
+
+Thanks for your continued support in helping us create the fluffiest client for the fediverse!


### PR DESCRIPTION
This PR makes the following change:

- Adds a `patreon.md` file to thank all of the Patreon subscribers for their support on Hyperspace (and links it on the README).

This PR does not make any changes to the existing codebase and should not affect the app in any way.