### PR TITLE
Make cards smaller when possible

### DIFF
--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -84,6 +84,7 @@ export class AppLayout extends Component<any, IAppLayoutState> {
         })
 
         this.streamNotifications()
+        
       }
 
       streamNotifications() {
@@ -153,7 +154,7 @@ export class AppLayout extends Component<any, IAppLayoutState> {
       }
 
       searchForQuery(what: string) {
-        window.location.href = isDesktopApp? "hyperspace://hyperspace/app/index.html#/search?query=" + what: "/#/search?query=" + what;
+        window.location.href = isDesktopApp()? "hyperspace://hyperspace/app/index.html#/search?query=" + what: "/#/search?query=" + what;
         window.location.reload;
       }
 

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -154,7 +154,7 @@ export class Post extends React.Component<any, IPostState> {
                                     <Typography>{status.card.description || "No description provided. Click with caution."}</Typography>
                                 </CardContent>
                                 {
-                                    status.card.image?
+                                    status.card.image && status.media_attachments.length <= 0?
                                     <CardMedia className={classes.postMedia} image={status.card.image}/>: <span/>
                                 }
                                 <CardContent>

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -151,7 +151,12 @@ export class Post extends React.Component<any, IPostState> {
                             <CardActionArea href={status.card.url} target="_blank" rel="noreferrer">
                                 <CardContent>
                                     <Typography gutterBottom variant="h6" component="h2">{status.card.title}</Typography>
-                                    <Typography>{status.card.description || "No description provided. Click with caution."}</Typography>
+                                    <Typography>
+                                        {
+                                            status.card.description.slice(0, 500) + (status.card.description.length > 500? "...": "") 
+                                            || "No description provided. Click with caution."
+                                        }
+                                    </Typography>
                                 </CardContent>
                                 {
                                     status.card.image && status.media_attachments.length <= 0?


### PR DESCRIPTION
This PR makes the following changes:

- Fixes any problems caused by #61 by converting `isDesktopApp` to the function rather than a variable
- Hides the card media when images/videos are present (fixes #47)
- Truncates media descriptions that are more than 500 characters in length and adds ellipses when necessary