### PR TITLE
Pleroma support (fixes #69)

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -102,6 +102,7 @@ class AboutPage extends Component<any, IAboutPageState> {
 
     render() {
         const { classes } = this.props;
+        
         return (
             <div className={classes.pageLayoutConstraints}>
                 <Paper>
@@ -117,7 +118,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                         <Typography className={classes.instanceHeaderText} variant="h4" component="p">{this.state.instance ? this.state.instance.uri: "Loading..."}</Typography>
                     </div>
                     <List className={classes.pageListConstraints}>
-                        <ListItem>
+                        {(localStorage['isPleroma'] == "false") && <ListItem>
                             <ListItemAvatar>
                                 <LinkableAvatar to={`/profile/${this.state.instance? this.state.instance.contact_account.id: 0}`} alt="Instance admin" src={this.state.instance? this.state.instance.contact_account.avatar_static: ""}/>
                             </ListItemAvatar>
@@ -137,7 +138,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                                     </LinkableIconButton>
                                 </Tooltip>
                             </ListItemSecondaryAction>
-                        </ListItem>
+                        </ListItem>}
                         <ListItem>
                             <ListItemAvatar>
                                 <Avatar>

--- a/src/utilities/accounts.tsx
+++ b/src/utilities/accounts.tsx
@@ -15,4 +15,7 @@ export function refreshUserAccountData() {
     }).catch((err: Error) => {
         console.error(err.message);
     });
+    client.get('/instance').then((resp: any) => {
+        localStorage.setItem('isPleroma', (resp.data.version.match(/Pleroma/) ? "true" : "false"))
+    })
 }


### PR DESCRIPTION
This PR makes the following changes:
- Removes (the check for) the instance's contact account from the About page to let it complete loading.
- A check is created to determine if the instance being used is a Pleroma instance, stored in `localStorage['isPleroma']` as "true" or "false" (strings).
- Fixes #69 , improves #65 

> Note: This PR comment has been edited to match Hyperspace Contribution Guidelines by @alicerunsonfedora .