### PR TITLE
Add user-account-switching

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0beta7",
-    "location": "desktop",
+    "location": "https://localhost:3000",
     "branding": {
         "name": "Hyperspace",
         "logo": "logo.svg",

--- a/public/electron.js
+++ b/public/electron.js
@@ -20,7 +20,7 @@ let mainWindow;
 // to when authorizing Hyperspace.
 protocol.registerSchemesAsPrivileged([
     { scheme: 'hyperspace', privileges: { standard: true, secure: true } }
-])
+]);
 
 /**
  * Determine whether the desktop app is on macOS
@@ -218,15 +218,8 @@ function createMenubar() {
                     click() {
                         safelyGoTo("hyperspace://hyperspace/app/#compose")
                     }
-                },
-                { type: 'separator' },
-                {
-                    label: 'Edit Profile',
-                    accelerator: "Shift+CmdOrCtrl+P",
-                    click() {
-                        safelyGoTo("hyperspace://hyperspace/app/#/you")
-                    }
-                },
+                }
+
             ]
         },
         {
@@ -284,7 +277,7 @@ function createMenubar() {
             ]
         },
         {
-            label: "Places",
+            label: "Timelines",
             submenu: [
                 {
                     label: 'Home',
@@ -308,27 +301,53 @@ function createMenubar() {
                     }
                 },
                 {
-                    label: 'Recommendations',
+                    label: 'Messages',
                     accelerator: "CmdOrCtrl+3",
+                    click() {
+                        safelyGoTo("hyperspace://hyperspace/app/#/messages")
+                    }
+                }
+            ]
+        },
+        {
+            label: "Account",
+            submenu: [
+                {
+                    label: 'Notifications',
+                    accelerator: "Alt+CmdOrCtrl+N",
+                    click() {
+                        safelyGoTo("hyperspace://hyperspace/app/#/notifications")
+                    }
+                },
+                {
+                    label: 'Recommendations...',
+                    accelerator: "Alt+CmdOrCtrl+R",
                     click() {
                         safelyGoTo("hyperspace://hyperspace/app/#/recommended")
                     }
                 },
                 { type: 'separator' },
                 {
-                    label: 'Notifications',
-                    accelerator: "CmdOrCtrl+4",
+                    label: 'Edit Profile',
+                    accelerator: "Shift+CmdOrCtrl+P",
                     click() {
-                        safelyGoTo("hyperspace://hyperspace/app/#/notifications")
+                        safelyGoTo("hyperspace://hyperspace/app/#/you")
                     }
                 },
                 {
-                    label: 'Messages',
-                    accelerator: "CmdOrCtrl+5",
+                    label: 'Blocked Servers',
+                    accelerator: "Shift+CmdOrCtrl+B",
                     click() {
-                        safelyGoTo("hyperspace://hyperspace/app/#/messages")
+                        safelyGoTo("hyperspace://hyperspace/app/#/blocked")
                     }
                 },
+                { type: 'separator'},
+                {
+                    label: 'Switch Accounts...',
+                    click() {
+                        safelyGoTo("hyperspace://hyperspace/app/#/welcome")
+                    }
+                }
             ]
         },
         {
@@ -357,7 +376,7 @@ function createMenubar() {
                 }
             ]
         }
-    ]
+    ];
 
     if (process.platform === 'darwin') {
         menuBar.unshift({
@@ -386,7 +405,7 @@ function createMenubar() {
                 { type: 'separator' },
                 { role: 'quit' }
             ]
-        })
+        });
 
         // Edit menu
         menuBar[2].submenu.push(
@@ -398,10 +417,10 @@ function createMenubar() {
                     { role: 'stopspeaking' }
                 ]
             }
-        )
+        );
 
         // Window menu
-        menuBar[5].submenu = [
+        menuBar[6].submenu = [
             { role: 'close' },
             { role: 'minimize' },
             { role: 'zoom' },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,6 @@ class App extends Component<any, IAppState> {
         this.removeBodyBackground();
         this.unlisten = this.props.history.listen(
             (location: Location, action: any) => {
-                console.log(location.pathname);
                 this.setState({
                     showLayout:
                         userLoggedIn() &&

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -114,7 +114,7 @@ export class AppLayout extends Component<any, IAppLayoutState> {
         this.streamNotifications();
     }
 
-    private getAccountData() {
+    getAccountData() {
         this.client
             .get("/accounts/verify_credentials")
             .then((resp: any) => {

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -120,6 +120,7 @@ export class AppLayout extends Component<any, IAppLayoutState> {
             .then((resp: any) => {
                 let data: UAccount = resp.data;
                 this.setState({ currentUser: data });
+                sessionStorage.setItem("id", data.id);
             })
             .catch((err: Error) => {
                 this.props.enqueueSnackbar(

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -72,7 +72,7 @@ interface IPostState {
     menuIsOpen: boolean;
     myVote?: [number];
     deletePostDialog: boolean;
-    myAccount?: Account;
+    myAccount?: string;
 }
 
 export class Post extends React.Component<any, IPostState> {
@@ -96,7 +96,7 @@ export class Post extends React.Component<any, IPostState> {
 
     componentWillMount() {
         this.setState({
-            myAccount: JSON.parse(localStorage.getItem("account") as string)
+            myAccount: sessionStorage.getItem("id") as string
         });
     }
 
@@ -831,7 +831,7 @@ export class Post extends React.Component<any, IPostState> {
                             </MenuItem>
                         </div>
                         {this.state.myAccount &&
-                        post.account.id == this.state.myAccount.id ? (
+                        post.account.id === this.state.myAccount ? (
                             <div>
                                 <Divider />
                                 <MenuItem

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -95,22 +95,9 @@ export class Post extends React.Component<any, IPostState> {
     }
 
     componentWillMount() {
-        this.client
-            .get("/accounts/verify_credentials")
-            .then((resp: any) => {
-                let account: Account = resp.data;
-                this.setState({
-                    myAccount: account
-                });
-            })
-            .catch((err: Error) => {
-                console.error(err);
-                this.setState({
-                    myAccount: JSON.parse(localStorage.getItem(
-                        "account"
-                    ) as string)
-                });
-            });
+        this.setState({
+            myAccount: JSON.parse(localStorage.getItem("account") as string)
+        });
     }
 
     togglePostMenu() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,12 @@ if (userLoggedIn()) {
     refreshUserAccountData();
 }
 
+window.onstorage = (event: any) => {
+    if (event.key == "account") {
+        window.location.reload();
+    }
+};
+
 ReactDOM.render(
     <HashRouter>
         <SnackbarProvider

--- a/src/pages/Compose.tsx
+++ b/src/pages/Compose.tsx
@@ -84,6 +84,10 @@ class Composer extends Component<any, IComposerState> {
     componentDidMount() {
         let state = this.getComposerParams(this.props);
         let text = state.acct ? `@${state.acct}: ` : "";
+        this.client.get("/accounts/verify_credentials").then((resp: any) => {
+            let account: UAccount = resp.data;
+            this.setState({ account });
+        });
         getConfig().then((config: any) => {
             this.setState({
                 federated: config.federation.allowPublicPosts,
@@ -439,7 +443,7 @@ class Composer extends Component<any, IComposerState> {
                                         event.target.value
                                     )
                                 }
-                            ></TextField>
+                            />
                         </Fade>
                     ) : null}
                     {this.state.visibility === "direct" ? (

--- a/src/pages/PageLayout.styles.tsx
+++ b/src/pages/PageLayout.styles.tsx
@@ -156,16 +156,16 @@ export const styles = (theme: Theme) =>
         pageProfileNameEmoji: {
             minHeight: theme.typography.h4.fontSize,
             fontWeight: theme.typography.fontWeightMedium,
-            '& img': {
-                height: theme.typography.h4.fontSize,
+            "& img": {
+                height: theme.typography.h4.fontSize
             }
         },
         pageProfileBioEmoji: {
-            height: '0.875rem',
-            '& img': {
-                height: '0.875rem',
+            height: "0.875rem",
+            "& img": {
+                height: "0.875rem",
                 paddingLeft: 4,
-                paddingRight: 4,
+                paddingRight: 4
             }
         },
         pageProfileStatsDiv: {

--- a/src/types/Account.tsx
+++ b/src/types/Account.tsx
@@ -26,9 +26,32 @@ export type Account = {
     bot: boolean | null;
 };
 
+/**
+ * Watered-down type for Mastodon accounts
+ */
 export type UAccount = {
     id: string;
     acct: string;
     display_name: string;
     avatar_static: string;
+};
+
+/**
+ * Account type for use with multi-account support
+ */
+export type MultiAccount = {
+    /**
+     * The host name of the account (ex.: mastodon.social)
+     */
+    host: string;
+
+    /**
+     * The username of the account (@test)
+     */
+    username: string;
+
+    /**
+     * The access token generated from the login
+     */
+    access_token: string;
 };

--- a/src/utilities/accounts.tsx
+++ b/src/utilities/accounts.tsx
@@ -18,6 +18,7 @@ export function refreshUserAccountData() {
         .then((resp: any) => {
             let account: Account = resp.data;
             localStorage.setItem("account", JSON.stringify(account));
+            sessionStorage.setItem("id", account.id);
 
             addAccountToRegistry(host, token, account.acct);
         })

--- a/src/utilities/accounts.tsx
+++ b/src/utilities/accounts.tsx
@@ -1,14 +1,10 @@
 import Mastodon from "megalodon";
+import { MultiAccount } from "../types/Account";
 
 export function userLoggedIn(): boolean {
-    if (
-        localStorage.getItem("baseurl") &&
-        localStorage.getItem("access_token")
-    ) {
-        return true;
-    } else {
-        return false;
-    }
+    return !!(
+        localStorage.getItem("baseurl") && localStorage.getItem("access_token")
+    );
 }
 
 export function refreshUserAccountData() {
@@ -30,4 +26,68 @@ export function refreshUserAccountData() {
             resp.data.version.match(/Pleroma/) ? "true" : "false"
         );
     });
+}
+
+/**
+ * Set the access token and base URL to a given multi-account user.
+ * @param account The multi-account from localStorage to use
+ */
+export function loginWithAccount(account: MultiAccount) {
+    if (localStorage.getItem("access_token") !== null) {
+        console.info(
+            "Existing login detected. Removing and using assigned token..."
+        );
+    }
+    localStorage.setItem("access_token", account.access_token);
+    localStorage.setItem("baseurl", account.host);
+}
+
+/**
+ * Gets the account registry.
+ * @returns A list of accounts
+ */
+function getAccountRegistry(): MultiAccount[] {
+    let accountRegistry: MultiAccount[] = [];
+
+    let accountRegistryString = localStorage.getItem("registry");
+    if (accountRegistryString !== null) {
+        accountRegistry = JSON.parse(accountRegistryString);
+    }
+    return accountRegistry;
+}
+
+/**
+ * Add an account to the multi-account registry if it doesn't exist already.
+ * @param base_url The base URL of the user (eg., the instance)
+ * @param access_token The access token for the user
+ * @param username The username of the user
+ */
+export function addAccountToRegistry(
+    base_url: string,
+    access_token: string,
+    username: string
+) {
+    const newAccount: MultiAccount = {
+        host: base_url,
+        username,
+        access_token
+    };
+
+    let accountRegistry = getAccountRegistry();
+
+    if (!accountRegistry.includes(newAccount)) {
+        accountRegistry.push(newAccount);
+    }
+
+    localStorage.setItem("registry", JSON.stringify(accountRegistry));
+}
+
+export function removeAccountFromRegistry(index: number) {
+    let accountRegistry = getAccountRegistry();
+    if (accountRegistry.length > index) {
+        accountRegistry.splice(index);
+    } else {
+        console.warn("Index of multi-account registry may be out of range.");
+    }
+    localStorage.setItem("registry", JSON.stringify(accountRegistry));
 }

--- a/src/utilities/accounts.tsx
+++ b/src/utilities/accounts.tsx
@@ -18,6 +18,7 @@ export function refreshUserAccountData() {
         .then((resp: any) => {
             let account: Account = resp.data;
             localStorage.setItem("account", JSON.stringify(account));
+
             addAccountToRegistry(host, token, account.acct);
         })
         .catch((err: Error) => {
@@ -70,6 +71,7 @@ export function addAccountToRegistry(
     access_token: string,
     username: string
 ) {
+    console.log("Firing!");
     const newAccount: MultiAccount = {
         host: base_url,
         username,
@@ -78,10 +80,10 @@ export function addAccountToRegistry(
 
     let accountRegistry = getAccountRegistry();
     const stringifiedRegistry = accountRegistry.map(account =>
-        account.toString()
+        JSON.stringify(account)
     );
 
-    if (stringifiedRegistry.indexOf(newAccount.toString()) === -1) {
+    if (stringifiedRegistry.indexOf(JSON.stringify(newAccount)) === -1) {
         accountRegistry.push(newAccount);
     }
 
@@ -99,13 +101,42 @@ export function removeAccountFromRegistry(
 
     if (typeof accountIdentifier === "number") {
         if (accountRegistry.length > accountIdentifier) {
+            if (
+                localStorage.getItem("access_token") ===
+                accountRegistry[accountIdentifier].access_token
+            ) {
+                localStorage.removeItem("baseurl");
+                localStorage.removeItem("access_token");
+            }
             accountRegistry.splice(accountIdentifier);
         } else {
             console.log("Multi account index may be out of range");
         }
     } else {
-        if (accountRegistry.includes(accountIdentifier)) {
-            accountRegistry.splice(accountRegistry.indexOf(accountIdentifier));
+        const stringifiedRegistry = accountRegistry.map(account =>
+            JSON.stringify(account)
+        );
+
+        const stringifiedAccountId = JSON.stringify(accountIdentifier);
+
+        if (
+            stringifiedRegistry.indexOf(
+                JSON.stringify(stringifiedAccountId)
+            ) !== -1
+        ) {
+            if (
+                localStorage.getItem("access_token") ===
+                accountIdentifier.access_token
+            ) {
+                localStorage.removeItem("baseurl");
+                localStorage.removeItem("access_token");
+            }
+
+            accountRegistry.splice(
+                stringifiedRegistry.indexOf(stringifiedAccountId)
+            );
         }
     }
+
+    localStorage.setItem("accountRegistry", JSON.stringify(accountRegistry));
 }

--- a/src/utilities/accounts.tsx
+++ b/src/utilities/accounts.tsx
@@ -71,7 +71,6 @@ export function addAccountToRegistry(
     access_token: string,
     username: string
 ) {
-    console.log("Firing!");
     const newAccount: MultiAccount = {
         host: base_url,
         username,

--- a/src/utilities/accounts.tsx
+++ b/src/utilities/accounts.tsx
@@ -82,12 +82,24 @@ export function addAccountToRegistry(
     localStorage.setItem("registry", JSON.stringify(accountRegistry));
 }
 
-export function removeAccountFromRegistry(index: number) {
+/**
+ * Remove an account from the multi-account registry, if possible
+ * @param accountIdentifier The index of the account from the registry or the MultiAccount object itself
+ */
+export function removeAccountFromRegistry(
+    accountIdentifier: number | MultiAccount
+) {
     let accountRegistry = getAccountRegistry();
-    if (accountRegistry.length > index) {
-        accountRegistry.splice(index);
+
+    if (typeof accountIdentifier === "number") {
+        if (accountRegistry.length > accountIdentifier) {
+            accountRegistry.splice(accountIdentifier);
+        } else {
+            console.log("Multi account index may be out of range");
+        }
     } else {
-        console.warn("Index of multi-account registry may be out of range.");
+        if (accountRegistry.includes(accountIdentifier)) {
+            accountRegistry.splice(accountRegistry.indexOf(accountIdentifier));
+        }
     }
-    localStorage.setItem("registry", JSON.stringify(accountRegistry));
 }


### PR DESCRIPTION
This PR makes the following changes:

- Adds a new `MultiAccount` type to store access token, username, and base URL.
- Adds new utilities that interact with localStorage key `accountRegistry` to add, login with, and remove accounts
- Modifies Welcome to now include user switching when visiting the welcome page
- Modifies AppLayout, Post, You, etc. components to dynamically get account information via a GET request to `/accounts/verify_credentials`) and only reads account's local storage as a last resort
- Modifies AppLayout's logout to also remove an account from the registry
- Fixes #37

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/13445064/66148880-e68d5300-e5df-11e9-9c61-4d999be883a5.png">
