### PR TITLE
Fix search loading issues on desktop apps

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -1,6 +1,6 @@
 // desktop.js
 // Electron script to run Hyperspace as an app
-// © 2018 Hyperspace developers. Licensed under Apache 2.0.
+// © 2018 Hyperspace developers. Licensed under NPL v1.
 
 const { app, Menu, protocol, BrowserWindow, shell, systemPreferences } = require('electron');
 const windowStateKeeper = require('electron-window-state');
@@ -137,7 +137,10 @@ function createWindow() {
             titleBarStyle: 'hiddenInset',
             vibrancy: "sidebar",
             transparent: darwin(),
-            backgroundColor: darwin()? "#80000000": "#FFF"
+            backgroundColor: darwin()? "#80000000": "#FFF",
+
+            // Hide the window until the contents load
+            show: false
         }
     );
 
@@ -161,6 +164,11 @@ function createWindow() {
             }
         });
     }
+
+    // Only show the window when ready
+    mainWindow.once('ready-to-show', () => {
+        mainWindow.show();
+    });
 
     // Delete the window when closed
     mainWindow.on('closed', () => {

--- a/public/electron.js
+++ b/public/electron.js
@@ -6,7 +6,6 @@ const { app, Menu, protocol, BrowserWindow, shell, systemPreferences } = require
 const windowStateKeeper = require('electron-window-state');
 const { autoUpdater } = require('electron-updater');
 const path = require('path');
-const os = require('os');
 
 // Check for any updates to the app
 autoUpdater.checkForUpdatesAndNotify();
@@ -26,7 +25,7 @@ protocol.registerSchemesAsPrivileged([
  * Determine whether the desktop app is on macOS
  * - Returns: Boolean of whether platform is Darwin
  */
-function darwin() {
+function isDarwin() {
     return process.platform === "darwin";
 }
 
@@ -82,7 +81,7 @@ function registerProtocol() {
             callback({error: -6});
         }
 
-        // Create a normalized version of the strring.
+        // Create a normalized version of the string.
         baseDirectory = path.normalize(baseDirectory);
 
         // Check to make sure the target isn't trying to go out of bounds.
@@ -136,8 +135,8 @@ function createWindow() {
             // Set some preferences that are specific to macOS.
             titleBarStyle: 'hiddenInset',
             vibrancy: "sidebar",
-            transparent: darwin(),
-            backgroundColor: darwin()? "#80000000": "#FFF",
+            transparent: isDarwin(),
+            backgroundColor: isDarwin()? "#80000000": "#FFF",
 
             // Hide the window until the contents load
             show: false
@@ -151,7 +150,7 @@ function createWindow() {
     mainWindow.loadURL("hyperspace://hyperspace/app/");
     
     // Watch for a change in macOS's dark mode and reload the window to apply changes, as well as accent color
-    if (darwin()) {
+    if (isDarwin()) {
         systemPreferences.subscribeNotification('AppleInterfaceThemeChangedNotification', () => {
             if (mainWindow != null) {
                 mainWindow.webContents.reload();
@@ -271,7 +270,7 @@ function createMenubar() {
                     label: 'Open Dev Tools',
                     click () {
                         try {
-                            mainWindow.webContents.openDevTools({mode: 'undocked'});
+                            mainWindow.webContents.openDevTools();
                         } catch (err) {
                             console.error("Couldn't open dev tools: " + err);
                         }
@@ -450,7 +449,7 @@ app.on('ready', () => {
 
 // Standard quit behavior changes for macOS
 app.on('window-all-closed', () => {
-    if (!darwin()) {
+    if (!isDarwin()) {
         app.quit()
     }
 });

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -235,7 +235,6 @@ export class AppLayout extends Component<any, IAppLayoutState> {
         window.location.href = isDesktopApp()
             ? "hyperspace://hyperspace/app/index.html#/search?query=" + what
             : "/#/search?query=" + what;
-        window.location.reload();
     }
 
     logOutAndRestart() {


### PR DESCRIPTION
This PR makes the following changes:

- Fixes the issue where the desktop apps reload without performing a search when searching something (fixes #100)
- Updates the Electron script to fix some names, licensing, and force the window to show only when the content has loaded