### PR TITLE
removes 'focused' outline from reblogged post menu

### DIFF
--- a/src/components/Post/Post.styles.tsx
+++ b/src/components/Post/Post.styles.tsx
@@ -14,6 +14,9 @@ export const styles = (theme: Theme) =>
             backgroundColor: theme.palette.secondary.main,
             marginBottom: theme.spacing.unit
         },
+        postReblogMenu: {
+            outline: "none",
+        },
         postContent: {
             paddingTop: 0,
             paddingBottom: 0,

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -798,7 +798,7 @@ export class Post extends React.Component<any, IPostState> {
                             }}
                         />
                         {post.reblog ? (
-                            <div>
+                            <div className={classes.postReblogMenu}>
                                 <LinkableMenuItem
                                     to={`/profile/${post.reblog.account.id}`}
                                 >


### PR DESCRIPTION
Signed-off-by: Travis Kohlbeck <me+git@travisk.info>

This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- adds class to reblog menu div
- adds `outline: none` to post styles
- closes #108 