### PR TITLE
Add Activity page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperspace",
-  "version": "1.0.0",
+  "version": "1.1.0-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1055,13 +1055,23 @@
       }
     },
     "@material-ui/icons": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.2.tgz",
-      "integrity": "sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.5.1.tgz",
+      "integrity": "sha512-YZ/BgJbXX4a0gOuKWb30mBaHaoXRqPanlePam83JQPZ/y4kl+3aW0Wv9tlR70hB5EGAkEJGW5m4ktJwMgxQAeA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "recompose": "0.28.0 - 0.30.0"
+        "@babel/runtime": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "@material-ui/system": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@date-io/moment": "^1.3.11",
     "@material-ui/core": "^3.9.3",
-    "@material-ui/icons": "^3.0.2",
+    "@material-ui/icons": "^4.5.1",
     "@types/emoji-mart": "^2.11.0",
     "@types/jest": "^24.0.18",
     "@types/node": "11.11.6",

--- a/public/electron.js
+++ b/public/electron.js
@@ -341,6 +341,13 @@ function createMenubar() {
                     }
                 },
                 {
+                    label: 'Follow Requests',
+                    accelerator: "Alt+CmdOrCtrl+E",
+                    click() {
+                        safelyGoTo("hyperspace://hyperspace/app/#/requests")
+                    }
+                },
+                {
                     label: 'Blocked Servers',
                     accelerator: "Shift+CmdOrCtrl+B",
                     click() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import Missingno from "./pages/Missingno";
 import Blocked from "./pages/Blocked";
 import You from "./pages/You";
 import RequestsPage from "./pages/Requests";
+import ActivityPage from "./pages/Activity";
 import { withSnackbar } from "notistack";
 import { PrivateRoute } from "./interfaces/overrides";
 import { userLoggedIn } from "./utilities/accounts";
@@ -125,6 +126,7 @@ class App extends Component<any, IAppState> {
                         component={RecommendationsPage}
                     />
                     <PrivateRoute path="/requests" component={RequestsPage} />
+                    <PrivateRoute path="/activity" component={ActivityPage} />
                 </div>
             </MuiThemeProvider>
         );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import RecommendationsPage from "./pages/Recommendations";
 import Missingno from "./pages/Missingno";
 import Blocked from "./pages/Blocked";
 import You from "./pages/You";
+import RequestsPage from "./pages/Requests";
 import { withSnackbar } from "notistack";
 import { PrivateRoute } from "./interfaces/overrides";
 import { userLoggedIn } from "./utilities/accounts";
@@ -123,6 +124,7 @@ class App extends Component<any, IAppState> {
                         path="/recommended"
                         component={RecommendationsPage}
                     />
+                    <PrivateRoute path="/requests" component={RequestsPage} />
                 </div>
             </MuiThemeProvider>
         );

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -42,6 +42,7 @@ import InfoIcon from "@material-ui/icons/Info";
 import CreateIcon from "@material-ui/icons/Create";
 import SupervisedUserCircleIcon from "@material-ui/icons/SupervisedUserCircle";
 import ExitToAppIcon from "@material-ui/icons/ExitToApp";
+import TrendingUpIcon from "@material-ui/icons/TrendingUp";
 
 import { styles } from "./AppLayout.styles";
 import { MultiAccount, UAccount } from "../../types/Account";
@@ -434,7 +435,13 @@ export class AppLayout extends Component<any, IAppLayoutState> {
                         </LinkableListItem>
                         <Divider />
                     </div>
-                    <ListSubheader>More</ListSubheader>
+                    <ListSubheader>Community</ListSubheader>
+                    <LinkableListItem button key="activity" to="/activity">
+                        <ListItemIcon>
+                            <TrendingUpIcon />
+                        </ListItemIcon>
+                        <ListItemText primary="Activity" />
+                    </LinkableListItem>
                     <LinkableListItem
                         button
                         key="recommended"
@@ -443,8 +450,10 @@ export class AppLayout extends Component<any, IAppLayoutState> {
                         <ListItemIcon>
                             <GroupIcon />
                         </ListItemIcon>
-                        <ListItemText primary="Who to follow" />
+                        <ListItemText primary="Recommended" />
                     </LinkableListItem>
+                    <Divider />
+                    <ListSubheader>More</ListSubheader>
                     <LinkableListItem button key="settings" to="/settings">
                         <ListItemIcon>
                             <SettingsIcon />

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -622,6 +622,15 @@ export class AppLayout extends Component<any, IAppLayoutState> {
                                                 </ListItemText>
                                             </LinkableListItem>
                                             <LinkableListItem
+                                                button={true}
+                                                to={"/requests"}
+                                            >
+                                                <ListItemText>
+                                                    Manage follow requests
+                                                </ListItemText>
+                                            </LinkableListItem>
+                                            <Divider />
+                                            <LinkableListItem
                                                 to={"/welcome"}
                                                 button={true}
                                             >

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -88,9 +88,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                         hyperspaceAdmin: account,
                         hyperspaceAdminName: config.admin.name,
                         federation: config.federation,
-                        developer: config.developer
-                            ? config.developer
-                            : false,
+                        developer: config.developer ? config.developer : false,
                         versionNumber: config.version,
                         brandName: config.branding
                             ? config.branding.name

--- a/src/pages/Activity.tsx
+++ b/src/pages/Activity.tsx
@@ -1,0 +1,156 @@
+import React, { Component } from "react";
+import {
+    withStyles,
+    Typography,
+    CircularProgress,
+    ListSubheader
+} from "@material-ui/core";
+import { styles } from "./PageLayout.styles";
+import { UAccount, Account } from "../types/Account";
+import { Tag } from "../types/Tag";
+import Mastodon from "megalodon";
+
+import FireplaceIcon from "@material-ui/icons/Fireplace";
+
+interface IActivityPageState {
+    user?: UAccount;
+    trendingTags?: [Tag];
+    profileDirectory?: [Account];
+    viewLoading: boolean;
+    viewLoaded?: boolean;
+    viewErrored?: boolean;
+}
+
+class ActivityPage extends Component<any, IActivityPageState> {
+    client: Mastodon;
+
+    constructor(props: any) {
+        super(props);
+
+        this.client = new Mastodon(
+            localStorage.getItem("access_token") as string,
+            localStorage.getItem("baseurl") + "/api/v1"
+        );
+
+        this.state = {
+            viewLoading: true
+        };
+    }
+
+    componentDidMount() {
+        this.getAccountData();
+
+        this.client
+            .get("/trends")
+            .then((resp: any) => {
+                let trendingTags: [Tag] = resp.data;
+                this.setState({ trendingTags });
+            })
+            .catch((err: Error) => {
+                this.setState({
+                    viewLoading: false,
+                    viewErrored: true
+                });
+                console.error(err.message);
+            });
+
+        this.client
+            .get("/directory", { local: true, order: "active" })
+            .then((resp: any) => {
+                let profileDirectory: [Account] = resp.data;
+                this.setState({
+                    profileDirectory,
+                    viewLoading: false,
+                    viewLoaded: true
+                });
+            })
+            .catch((err: Error) => {
+                this.setState({
+                    viewLoading: false,
+                    viewErrored: true
+                });
+                console.log(err.message);
+            });
+    }
+
+    getAccountData() {
+        this.client
+            .get("/accounts/verify_credentials")
+            .then((resp: any) => {
+                let data: UAccount = resp.data;
+                this.setState({ user: data });
+            })
+            .catch((err: Error) => {
+                this.props.enqueueSnackbar(
+                    "Couldn't find profile info: " + err.name
+                );
+                console.error(err.message);
+                let acct = localStorage.getItem("account") as string;
+                this.setState({ user: JSON.parse(acct) });
+            });
+    }
+
+    render() {
+        const { classes } = this.props;
+        return (
+            <div className={classes.pageLayoutConstraints}>
+                <div
+                    style={{
+                        textAlign: "center"
+                    }}
+                >
+                    <FireplaceIcon style={{ fontSize: 64 }} />
+                    <Typography variant="h6">
+                        Hey there,{" "}
+                        {this.state.user
+                            ? this.state.user.display_name ||
+                              this.state.user.acct
+                            : "user"}
+                        !
+                    </Typography>
+                    <Typography paragraph>
+                        Take a look at what's been happening on your instance.
+                    </Typography>
+                </div>
+                {this.state.viewLoaded ? (
+                    <div>
+                        <ListSubheader>Trending hashtags</ListSubheader>
+                        {this.state.trendingTags &&
+                        this.state.trendingTags.length > 0 ? (
+                            <div></div>
+                        ) : (
+                            <Typography paragraph>
+                                It looks like there aren't any trending tags on
+                                your instance as of right now.
+                            </Typography>
+                        )}
+                        <ListSubheader>
+                            Active on profile directory
+                        </ListSubheader>
+                        {this.state.profileDirectory &&
+                        this.state.profileDirectory.length > 0 ? (
+                            <div></div>
+                        ) : (
+                            <Typography paragraph>
+                                It looks like there aren't any people in the
+                                profile directory yet.
+                            </Typography>
+                        )}
+                    </div>
+                ) : null}
+                {this.state.viewLoading ? (
+                    <div style={{ textAlign: "center" }}>
+                        <CircularProgress
+                            className={classes.progress}
+                            color="primary"
+                        />
+                    </div>
+                ) : (
+                    <span />
+                )}
+            </div>
+        );
+    }
+}
+
+export default withStyles(styles)(ActivityPage);

--- a/src/pages/Activity.tsx
+++ b/src/pages/Activity.tsx
@@ -3,19 +3,35 @@ import {
     withStyles,
     Typography,
     CircularProgress,
-    ListSubheader
+    ListSubheader,
+    Link,
+    Paper,
+    List,
+    ListItem,
+    ListItemText,
+    ListItemAvatar,
+    ListItemSecondaryAction,
+    Tooltip,
+    IconButton
 } from "@material-ui/core";
 import { styles } from "./PageLayout.styles";
 import { UAccount, Account } from "../types/Account";
 import { Tag } from "../types/Tag";
 import Mastodon from "megalodon";
+import { LinkableAvatar, LinkableIconButton } from "../interfaces/overrides";
+import moment from "moment";
 
 import FireplaceIcon from "@material-ui/icons/Fireplace";
+import TrendingUpIcon from "@material-ui/icons/TrendingUp";
+import SearchIcon from "@material-ui/icons/Search";
+import OpenInNewIcon from "@material-ui/icons/OpenInNew";
+import AssignmentIndIcon from "@material-ui/icons/AssignmentInd";
 
 interface IActivityPageState {
     user?: UAccount;
     trendingTags?: [Tag];
-    profileDirectory?: [Account];
+    activeProfileDirectory?: [Account];
+    newProfileDirectory?: [Account];
     viewLoading: boolean;
     viewLoaded?: boolean;
     viewErrored?: boolean;
@@ -41,7 +57,7 @@ class ActivityPage extends Component<any, IActivityPageState> {
         this.getAccountData();
 
         this.client
-            .get("/trends")
+            .get("/trends", { limit: 3 })
             .then((resp: any) => {
                 let trendingTags: [Tag] = resp.data;
                 this.setState({ trendingTags });
@@ -55,11 +71,27 @@ class ActivityPage extends Component<any, IActivityPageState> {
             });
 
         this.client
-            .get("/directory", { local: true, order: "active" })
+            .get("/directory", { local: true, order: "active", limit: 5 })
             .then((resp: any) => {
                 let profileDirectory: [Account] = resp.data;
                 this.setState({
-                    profileDirectory,
+                    activeProfileDirectory: profileDirectory
+                });
+            })
+            .catch((err: Error) => {
+                this.setState({
+                    viewLoading: false,
+                    viewErrored: true
+                });
+                console.log(err.message);
+            });
+
+        this.client
+            .get("/directory", { local: true, order: "new", limit: 5 })
+            .then((resp: any) => {
+                let profileDirectory: [Account] = resp.data;
+                this.setState({
+                    newProfileDirectory: profileDirectory,
                     viewLoading: false,
                     viewLoaded: true
                 });
@@ -117,27 +149,174 @@ class ActivityPage extends Component<any, IActivityPageState> {
                         <ListSubheader>Trending hashtags</ListSubheader>
                         {this.state.trendingTags &&
                         this.state.trendingTags.length > 0 ? (
-                            <div></div>
+                            <Paper>
+                                <List className={classes.pageListConstraints}>
+                                    {this.state.trendingTags.map((tag: Tag) => (
+                                        <ListItem
+                                            id={"trending_tag_" + tag.name}
+                                            key={"trending_tag_" + tag.name}
+                                        >
+                                            <ListItemAvatar>
+                                                <TrendingUpIcon />
+                                            </ListItemAvatar>
+                                            <ListItemText
+                                                primary={"#" + tag.name}
+                                                secondary={
+                                                    tag.history
+                                                        ? `${tag.history[0].accounts} people talking in ${tag.history[0].uses} posts`
+                                                        : "Couldn't determine usage"
+                                                }
+                                            />
+                                            <ListItemSecondaryAction>
+                                                <Tooltip title="Search">
+                                                    <LinkableIconButton
+                                                        to={`/search?query=tag:${tag.name}`}
+                                                    >
+                                                        <SearchIcon />
+                                                    </LinkableIconButton>
+                                                </Tooltip>
+                                                <Tooltip title="View on web">
+                                                    <IconButton>
+                                                        <OpenInNewIcon />
+                                                    </IconButton>
+                                                </Tooltip>
+                                            </ListItemSecondaryAction>
+                                        </ListItem>
+                                    ))}
+                                </List>
+                            </Paper>
                         ) : (
                             <Typography paragraph>
                                 It looks like there aren't any trending tags on
                                 your instance as of right now.
                             </Typography>
                         )}
-                        <ListSubheader>
-                            Active on profile directory
-                        </ListSubheader>
-                        {this.state.profileDirectory &&
-                        this.state.profileDirectory.length > 0 ? (
-                            <div></div>
+                        <br />
+                        <ListSubheader>Who's been active</ListSubheader>
+                        {this.state.activeProfileDirectory &&
+                        this.state.activeProfileDirectory.length > 0 ? (
+                            <Paper>
+                                <List className={classes.pageListConstraints}>
+                                    {this.state.activeProfileDirectory.map(
+                                        (account: Account) => (
+                                            <ListItem
+                                                key={
+                                                    "account_active_" +
+                                                    account.acct
+                                                }
+                                                id={
+                                                    "account_active_" +
+                                                    account.acct
+                                                }
+                                            >
+                                                <ListItemAvatar>
+                                                    <LinkableAvatar
+                                                        to={`/profile/${account.id}`}
+                                                        src={
+                                                            account.avatar_static
+                                                        }
+                                                    />
+                                                </ListItemAvatar>
+                                                <ListItemText
+                                                    primary={
+                                                        `${account.display_name} (@${account.username})` ||
+                                                        `@${account.username}`
+                                                    }
+                                                    secondary={`Last posted ${moment(
+                                                        account.last_status_at
+                                                    )
+                                                        .startOf("minute")
+                                                        .fromNow()}`}
+                                                />
+                                                <ListItemSecondaryAction>
+                                                    <Tooltip title="View account">
+                                                        <LinkableIconButton
+                                                            to={`/profile/${account.id}`}
+                                                        >
+                                                            <AssignmentIndIcon />
+                                                        </LinkableIconButton>
+                                                    </Tooltip>
+                                                </ListItemSecondaryAction>
+                                            </ListItem>
+                                        )
+                                    )}
+                                </List>
+                            </Paper>
                         ) : (
                             <Typography paragraph>
-                                It looks like there aren't any people in the
-                                profile directory yet.
+                                It looks like there aren't any active people in
+                                the profile directory yet.
+                            </Typography>
+                        )}
+                        <br />
+                        <ListSubheader>New arrivals</ListSubheader>
+                        {this.state.newProfileDirectory &&
+                        this.state.newProfileDirectory.length > 0 ? (
+                            <Paper>
+                                <List className={classes.pageListConstraints}>
+                                    {this.state.newProfileDirectory.map(
+                                        (account: Account) => (
+                                            <ListItem
+                                                key={
+                                                    "account_new_" +
+                                                    account.acct
+                                                }
+                                                id={
+                                                    "account_new_" +
+                                                    account.acct
+                                                }
+                                            >
+                                                <ListItemAvatar>
+                                                    <LinkableAvatar
+                                                        to={`/profile/${account.id}`}
+                                                        src={
+                                                            account.avatar_static
+                                                        }
+                                                    />
+                                                </ListItemAvatar>
+                                                <ListItemText
+                                                    primary={
+                                                        `${account.display_name} (@${account.username})` ||
+                                                        `@${account.username}`
+                                                    }
+                                                    secondary={`Joined ${moment(
+                                                        account.created_at
+                                                    )
+                                                        .startOf("minute")
+                                                        .fromNow()}`}
+                                                />
+                                                <ListItemSecondaryAction>
+                                                    <Tooltip title="View account">
+                                                        <LinkableIconButton
+                                                            to={`/profile/${account.id}`}
+                                                        >
+                                                            <AssignmentIndIcon />
+                                                        </LinkableIconButton>
+                                                    </Tooltip>
+                                                </ListItemSecondaryAction>
+                                            </ListItem>
+                                        )
+                                    )}
+                                </List>
+                            </Paper>
+                        ) : (
+                            <Typography paragraph>
+                                It looks like there aren't any new arrivals
+                                listed in the profile directory yet.
                             </Typography>
                         )}
                     </div>
                 ) : null}
+                {this.state.viewErrored ? (
+                    <Paper className={classes.errorCard}>
+                        <Typography variant="h4">Bummer.</Typography>
+                        <Typography variant="h6">
+                            Something went wrong when loading instance activity.
+                        </Typography>
+                    </Paper>
+                ) : (
+                    <span />
+                )}
                 {this.state.viewLoading ? (
                     <div style={{ textAlign: "center" }}>
                         <CircularProgress
@@ -148,6 +327,15 @@ class ActivityPage extends Component<any, IActivityPageState> {
                 ) : (
                     <span />
                 )}
+                <br />
+                <div>
+                    <Typography variant="caption">
+                        Trending hashtags and the profile directory may not
+                        appear here if your instance isn't up to date. Check the{" "}
+                        <Link href="/#/about">about page</Link> to see if your
+                        instance is running the latest version.
+                    </Typography>
+                </div>
             </div>
         );
     }

--- a/src/pages/Recommendations.tsx
+++ b/src/pages/Recommendations.tsx
@@ -32,7 +32,6 @@ interface IRecommendationsPageState {
     viewDidError?: Boolean;
     viewDidErrorCode?: string;
     followSuggestions?: [Account];
-    trendingTags?: [any];
 }
 
 class RecommendationsPage extends Component<

--- a/src/pages/Recommendations.tsx
+++ b/src/pages/Recommendations.tsx
@@ -6,24 +6,20 @@ import {
     ListItem,
     Paper,
     ListItemText,
-    Avatar,
     ListItemSecondaryAction,
     ListItemAvatar,
     ListSubheader,
     CircularProgress,
     IconButton,
-    Divider,
-    Tooltip
+    Tooltip,
+    Link
 } from "@material-ui/core";
 import { styles } from "./PageLayout.styles";
 import Mastodon from "megalodon";
 import { Account } from "../types/Account";
 import { LinkableIconButton, LinkableAvatar } from "../interfaces/overrides";
-import AccountCircleIcon from "@material-ui/icons/AccountCircle";
 import AssignmentIndIcon from "@material-ui/icons/AssignmentInd";
 import PersonAddIcon from "@material-ui/icons/PersonAdd";
-import CheckIcon from "@material-ui/icons/Check";
-import CloseIcon from "@material-ui/icons/Close";
 import { withSnackbar, withSnackbarProps } from "notistack";
 
 interface IRecommendationsPageProps extends withSnackbarProps {
@@ -35,8 +31,8 @@ interface IRecommendationsPageState {
     viewDidLoad?: boolean;
     viewDidError?: Boolean;
     viewDidErrorCode?: string;
-    requestedFollows?: [Account];
     followSuggestions?: [Account];
+    trendingTags?: [any];
 }
 
 class RecommendationsPage extends Component<
@@ -57,21 +53,6 @@ class RecommendationsPage extends Component<
     }
 
     componentDidMount() {
-        this.client
-            .get("/follow_requests")
-            .then((resp: any) => {
-                let requestedFollows: [Account] = resp.data;
-                this.setState({ requestedFollows });
-            })
-            .catch((err: Error) => {
-                this.setState({
-                    viewIsLoading: false,
-                    viewDidError: true,
-                    viewDidErrorCode: err.name
-                });
-                console.error(err.message);
-            });
-
         this.client
             .get("/suggestions")
             .then((resp: any) => {
@@ -123,110 +104,6 @@ class RecommendationsPage extends Component<
                 );
                 console.error(err.message);
             });
-    }
-
-    handleFollowRequest(acct: Account, type: "authorize" | "reject") {
-        this.client
-            .post(`/follow_requests/${acct.id}/${type}`)
-            .then((resp: any) => {
-                let requestedFollows = this.state.requestedFollows;
-                if (requestedFollows) {
-                    requestedFollows.forEach(
-                        (request: Account, index: number) => {
-                            if (requestedFollows && request.id === acct.id) {
-                                requestedFollows.splice(index, 1);
-                            }
-                        }
-                    );
-                }
-                this.setState({ requestedFollows });
-
-                let verb: string = type;
-                verb === "authorize"
-                    ? (verb = "authorized")
-                    : (verb = "rejected");
-                this.props.enqueueSnackbar(`You have ${verb} this request.`);
-            })
-            .catch((err: Error) => {
-                this.props.enqueueSnackbar(
-                    `Couldn't ${type} this request: ${err.name}`,
-                    { variant: "error" }
-                );
-                console.error(err.message);
-            });
-    }
-
-    showFollowRequests() {
-        const { classes } = this.props;
-        return (
-            <div>
-                <ListSubheader>Follow requests</ListSubheader>
-                <Paper className={classes.pageListConstraints}>
-                    <List>
-                        {this.state.requestedFollows
-                            ? this.state.requestedFollows.map(
-                                  (request: Account) => {
-                                      return (
-                                          <ListItem key={request.id}>
-                                              <ListItemAvatar>
-                                                  <LinkableAvatar
-                                                      to={`/profile/${request.id}`}
-                                                      alt={request.username}
-                                                      src={
-                                                          request.avatar_static
-                                                      }
-                                                  />
-                                              </ListItemAvatar>
-                                              <ListItemText
-                                                  primary={
-                                                      request.display_name ||
-                                                      request.acct
-                                                  }
-                                                  secondary={request.acct}
-                                              />
-                                              <ListItemSecondaryAction>
-                                                  <Tooltip title="Accept request">
-                                                      <IconButton
-                                                          onClick={() =>
-                                                              this.handleFollowRequest(
-                                                                  request,
-                                                                  "authorize"
-                                                              )
-                                                          }
-                                                      >
-                                                          <CheckIcon />
-                                                      </IconButton>
-                                                  </Tooltip>
-                                                  <Tooltip title="Reject request">
-                                                      <IconButton
-                                                          onClick={() =>
-                                                              this.handleFollowRequest(
-                                                                  request,
-                                                                  "reject"
-                                                              )
-                                                          }
-                                                      >
-                                                          <CloseIcon />
-                                                      </IconButton>
-                                                  </Tooltip>
-                                                  <Tooltip title="View profile">
-                                                      <LinkableIconButton
-                                                          to={`/profile/${request.id}`}
-                                                      >
-                                                          <AccountCircleIcon />
-                                                      </LinkableIconButton>
-                                                  </Tooltip>
-                                              </ListItemSecondaryAction>
-                                          </ListItem>
-                                      );
-                                  }
-                              )
-                            : null}
-                    </List>
-                </Paper>
-                <br />
-            </div>
-        );
     }
 
     showFollowSuggestions() {
@@ -295,23 +172,6 @@ class RecommendationsPage extends Component<
             <div className={classes.pageLayoutConstraints}>
                 {this.state.viewDidLoad ? (
                     <div>
-                        {this.state.requestedFollows &&
-                        this.state.requestedFollows.length > 0 ? (
-                            this.showFollowRequests()
-                        ) : (
-                            <div
-                                className={
-                                    classes.pageLayoutEmptyTextConstraints
-                                }
-                            >
-                                <Typography variant="h6">
-                                    You don't have any follow requests.
-                                </Typography>
-                                <br />
-                            </div>
-                        )}
-                        <Divider />
-                        <br />
                         {this.state.followSuggestions &&
                         this.state.followSuggestions.length > 0 ? (
                             this.showFollowSuggestions()
@@ -330,13 +190,19 @@ class RecommendationsPage extends Component<
                                 </Typography>
                             </div>
                         )}
+                        <br />
+                        <Typography variant="caption" paragraph>
+                            Looking for follow requests? You can find them in
+                            Settings or in the account menu. You can also{" "}
+                            <Link href="/#/requests">click here</Link>.
+                        </Typography>
                     </div>
                 ) : null}
                 {this.state.viewDidError ? (
                     <Paper className={classes.errorCard}>
                         <Typography variant="h4">Bummer.</Typography>
                         <Typography variant="h6">
-                            Something went wrong when loading this timeline.
+                            Something went wrong when loading recommendations.
                         </Typography>
                         <Typography>
                             {this.state.viewDidErrorCode

--- a/src/pages/Requests.tsx
+++ b/src/pages/Requests.tsx
@@ -17,10 +17,11 @@ import { styles } from "./PageLayout.styles";
 import { Account } from "../types/Account";
 import Mastodon from "megalodon";
 import { LinkableAvatar, LinkableIconButton } from "../interfaces/overrides";
-import CheckIcon from "@material-ui/core/SvgIcon/SvgIcon";
+import CheckIcon from "@material-ui/icons/Check";
 import AccountCircleIcon from "@material-ui/icons/AccountCircle";
 import CloseIcon from "@material-ui/icons/Close";
 import CheckCircleIcon from "@material-ui/icons/CheckCircle";
+import { withSnackbar } from "notistack";
 
 interface IRequestsPageState {
     viewLoading: boolean;
@@ -211,4 +212,4 @@ class RequestsPage extends Component<any, IRequestsPageState> {
     }
 }
 
-export default withStyles(styles)(RequestsPage);
+export default withStyles(styles)(withSnackbar(RequestsPage));

--- a/src/pages/Requests.tsx
+++ b/src/pages/Requests.tsx
@@ -1,0 +1,214 @@
+import React, { Component } from "react";
+import {
+    CircularProgress,
+    IconButton,
+    List,
+    ListItem,
+    ListItemAvatar,
+    ListItemSecondaryAction,
+    ListItemText,
+    ListSubheader,
+    Paper,
+    Tooltip,
+    Typography,
+    withStyles
+} from "@material-ui/core";
+import { styles } from "./PageLayout.styles";
+import { Account } from "../types/Account";
+import Mastodon from "megalodon";
+import { LinkableAvatar, LinkableIconButton } from "../interfaces/overrides";
+import CheckIcon from "@material-ui/core/SvgIcon/SvgIcon";
+import AccountCircleIcon from "@material-ui/icons/AccountCircle";
+import CloseIcon from "@material-ui/icons/Close";
+import CheckCircleIcon from "@material-ui/icons/CheckCircle";
+
+interface IRequestsPageState {
+    viewLoading: boolean;
+    viewLoaded?: boolean;
+    viewErrored?: boolean;
+    requestedAccounts?: [Account];
+}
+
+class RequestsPage extends Component<any, IRequestsPageState> {
+    client: Mastodon;
+
+    constructor(props: any) {
+        super(props);
+
+        this.client = new Mastodon(
+            localStorage.getItem("access_token") as string,
+            localStorage.getItem("baseurl") + "/api/v1"
+        );
+        this.state = {
+            viewLoading: true
+        };
+    }
+
+    componentDidMount() {
+        this.client
+            .get("/follow_requests")
+            .then((resp: any) => {
+                let requestedAccounts: [Account] = resp.data;
+                this.setState({
+                    requestedAccounts,
+                    viewLoading: false,
+                    viewLoaded: true
+                });
+            })
+            .catch((err: Error) => {
+                this.setState({
+                    viewLoading: false,
+                    viewErrored: true
+                });
+                console.error(err.message);
+            });
+    }
+
+    handleFollowRequest(acct: Account, type: "authorize" | "reject") {
+        this.client
+            .post(`/follow_requests/${acct.id}/${type}`)
+            .then((resp: any) => {
+                let requestedAccounts = this.state.requestedAccounts;
+                if (requestedAccounts) {
+                    requestedAccounts.forEach(
+                        (request: Account, index: number) => {
+                            if (requestedAccounts && request.id === acct.id) {
+                                requestedAccounts.splice(index, 1);
+                            }
+                        }
+                    );
+                }
+                this.setState({ requestedAccounts });
+
+                let verb: string = type;
+                verb === "authorize"
+                    ? (verb = "authorized")
+                    : (verb = "rejected");
+                this.props.enqueueSnackbar(`You have ${verb} this request.`);
+            })
+            .catch((err: Error) => {
+                this.props.enqueueSnackbar(
+                    `Couldn't ${type} this request: ${err.name}`,
+                    { variant: "error" }
+                );
+                console.error(err.message);
+            });
+    }
+
+    showFollowRequests() {
+        const { classes } = this.props;
+        return (
+            <div>
+                <ListSubheader>Follow requests</ListSubheader>
+                <Paper className={classes.pageListConstraints}>
+                    <List>
+                        {this.state.requestedAccounts
+                            ? this.state.requestedAccounts.map(
+                                  (request: Account) => {
+                                      return (
+                                          <ListItem key={request.id}>
+                                              <ListItemAvatar>
+                                                  <LinkableAvatar
+                                                      to={`/profile/${request.id}`}
+                                                      alt={request.username}
+                                                      src={
+                                                          request.avatar_static
+                                                      }
+                                                  />
+                                              </ListItemAvatar>
+                                              <ListItemText
+                                                  primary={
+                                                      request.display_name ||
+                                                      request.acct
+                                                  }
+                                                  secondary={request.acct}
+                                              />
+                                              <ListItemSecondaryAction>
+                                                  <Tooltip title="Accept request">
+                                                      <IconButton
+                                                          onClick={() =>
+                                                              this.handleFollowRequest(
+                                                                  request,
+                                                                  "authorize"
+                                                              )
+                                                          }
+                                                      >
+                                                          <CheckIcon />
+                                                      </IconButton>
+                                                  </Tooltip>
+                                                  <Tooltip title="Reject request">
+                                                      <IconButton
+                                                          onClick={() =>
+                                                              this.handleFollowRequest(
+                                                                  request,
+                                                                  "reject"
+                                                              )
+                                                          }
+                                                      >
+                                                          <CloseIcon />
+                                                      </IconButton>
+                                                  </Tooltip>
+                                                  <Tooltip title="View profile">
+                                                      <LinkableIconButton
+                                                          to={`/profile/${request.id}`}
+                                                      >
+                                                          <AccountCircleIcon />
+                                                      </LinkableIconButton>
+                                                  </Tooltip>
+                                              </ListItemSecondaryAction>
+                                          </ListItem>
+                                      );
+                                  }
+                              )
+                            : null}
+                    </List>
+                </Paper>
+                <br />
+            </div>
+        );
+    }
+
+    render() {
+        const { classes } = this.props;
+        return (
+            <div className={classes.pageLayoutConstraints}>
+                {this.state.viewLoaded ? (
+                    <div>
+                        {this.state.requestedAccounts &&
+                        this.state.requestedAccounts.length > 0 ? (
+                            this.showFollowRequests()
+                        ) : (
+                            <div
+                                className={
+                                    classes.pageLayoutEmptyTextConstraints
+                                }
+                                style={{ textAlign: "center" }}
+                            >
+                                <CheckCircleIcon
+                                    color="action"
+                                    style={{ fontSize: 48 }}
+                                />
+                                <Typography variant="h6">
+                                    You don't have any follow requests.
+                                </Typography>
+                                <br />
+                            </div>
+                        )}
+                    </div>
+                ) : null}
+                {this.state.viewLoading ? (
+                    <div style={{ textAlign: "center" }}>
+                        <CircularProgress
+                            className={classes.progress}
+                            color="primary"
+                        />
+                    </div>
+                ) : (
+                    <span />
+                )}
+            </div>
+        );
+    }
+}
+
+export default withStyles(styles)(RequestsPage);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -62,6 +62,8 @@ import BellAlertIcon from "mdi-material-ui/BellAlert";
 import RefreshIcon from "@material-ui/icons/Refresh";
 import UndoIcon from "@material-ui/icons/Undo";
 import DomainDisabledIcon from "@material-ui/icons/DomainDisabled";
+import AccountSettingsIcon from "mdi-material-ui/AccountSettings";
+
 import { Config } from "../types/Config";
 import { Account } from "../types/Account";
 import Mastodon from "megalodon";
@@ -502,7 +504,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                                 </div>
                                 <div className={classes.pageGrow} />
                                 <Toolbar>
-                                    <Tooltip title="Edit Profile">
+                                    <Tooltip title="Edit profile">
                                         <LinkableIconButton
                                             to={"/you"}
                                             color="inherit"
@@ -516,6 +518,14 @@ class SettingsPage extends Component<any, ISettingsState> {
                                             color="inherit"
                                         >
                                             <DomainDisabledIcon />
+                                        </LinkableIconButton>
+                                    </Tooltip>
+                                    <Tooltip title="Manage follow requests">
+                                        <LinkableIconButton
+                                            to={"/requests"}
+                                            color="inherit"
+                                        >
+                                            <AccountSettingsIcon />
                                         </LinkableIconButton>
                                     </Tooltip>
                                     <Tooltip title="Configure on Mastodon">

--- a/src/types/Account.tsx
+++ b/src/types/Account.tsx
@@ -14,6 +14,7 @@ export type Account = {
     followers_count: number;
     following_count: number;
     statuses_count: number;
+    last_status_at: string;
     note: string;
     url: string;
     avatar: string;

--- a/src/types/History.tsx
+++ b/src/types/History.tsx
@@ -1,0 +1,5 @@
+export type History = {
+    day: string;
+    uses: number;
+    accounts: number;
+};

--- a/src/types/Tag.tsx
+++ b/src/types/Tag.tsx
@@ -1,4 +1,7 @@
+import { History } from "./History";
+
 export type Tag = {
     name: string;
     url: string;
+    history?: [History];
 };


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Moves follow requests to its own page at `/requests` (links available in Recommended page, account menu, and Settings)
- Renames "Who to follow" page to "Recommended"
- Adds "Activity" page at `/activity` to let people see trending hashtags, active people, and new arrivals on their instance
- Updates Material UI icons package to 4.5.1
- Updates the Account and Tag types, as well as introduces the History type

- [ ] This is a release check.

![image](https://user-images.githubusercontent.com/13445064/68075014-c84e7a80-fd78-11e9-906d-51e00d47b6df.png)
