### PR TITLE
Moves Tooltip from bottom to left

### DIFF
--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -646,7 +646,7 @@ export class Post extends React.Component<any, IPostState> {
                             />
                         }
                         action={
-                            <Tooltip title="More">
+                            <Tooltip title="More" placement="left">
                                 <IconButton
                                     key={`${post.id}_submenu`}
                                     id={`${post.id}_submenu`}


### PR DESCRIPTION
This PR makes the following changes:
- Moves the Post's "More" Button's Tooltip from below the Button to the left (adds the value "left" to the attribute "placement")
- Fixes #115 