### PR TITLE
HD-12 Brand rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperspace",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperspace",
-  "productName": "Hyperspace",
+  "productName": "Hyperspace Desktop",
   "version": "1.0.3",
   "description": "A beautiful, fluffy client for the fediverse",
   "author": "Marquis Kurt <hyperspacedev@marquiskurt.net>",

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -139,7 +139,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                             <Typography variant="h4" component="p">
                                 {this.state.brandName
                                     ? this.state.brandName
-                                    : "Hyperspace"}
+                                    : "Hyperspace Desktop"}
                             </Typography>
                             <Typography>
                                 Version{" "}
@@ -470,7 +470,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                         developers. All rights reserved.
                     </Typography>
                     <Typography variant="caption" paragraph>
-                        {this.state ? this.state.brandName : "Hyperspace"} is
+                        {this.state ? this.state.brandName : "Hyperspace"} Desktop is
                         made possible by the{" "}
                         <Link
                             href={"https://material-ui.com"}


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Changed strings from "Hyperspace" to "Hyperspace Desktop" in the about page and package.json
- Closes [HD-12]
- Edited start script by removing HTTPS env var

- [ ] This is a release check.

[HD-12]: https://hyperspacedev.atlassian.net/browse/HD-12