### PR TITLE
[HD-17] Fix Pleroma about page blank regression

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,12 +22,6 @@ if (userLoggedIn()) {
     refreshUserAccountData();
 }
 
-window.onstorage = (event: any) => {
-    if (event.key == "account") {
-        window.location.reload();
-    }
-};
-
 ReactDOM.render(
     <HashRouter>
         <SnackbarProvider

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -23,11 +23,9 @@ import AssignmentIcon from "@material-ui/icons/Assignment";
 import AssignmentIndIcon from "@material-ui/icons/AssignmentInd";
 import NetworkCheckIcon from "@material-ui/icons/NetworkCheck";
 import UpdateIcon from "@material-ui/icons/Update";
-import InfoIcon from "@material-ui/icons/Info";
 import NotesIcon from "@material-ui/icons/Notes";
 import CodeIcon from "@material-ui/icons/Code";
 import TicketAccountIcon from "mdi-material-ui/TicketAccount";
-import MastodonIcon from "mdi-material-ui/Mastodon";
 import EditIcon from "@material-ui/icons/Edit";
 import VpnKeyIcon from "@material-ui/icons/VpnKey";
 
@@ -107,8 +105,17 @@ class AboutPage extends Component<any, IAboutPageState> {
         });
     }
 
+    shouldRenderInstanceContact(): boolean {
+        if (this.state.instance != null) {
+            return this.state.instance.version.match(/Pleroma/) == null;
+        } else {
+            return false;
+        }
+    }
+
     render() {
         const { classes } = this.props;
+        console.info(this.shouldRenderInstanceContact());
 
         return (
             <div className={classes.pageLayoutConstraints}>
@@ -297,7 +304,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                         </div>
                     </div>
                     <List className={classes.pageListConstraints}>
-                        {localStorage["isPleroma"] == "false" && (
+                        {this.shouldRenderInstanceContact() ? (
                             <ListItem>
                                 <ListItemAvatar>
                                     <LinkableAvatar
@@ -352,7 +359,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                                     </Tooltip>
                                 </ListItemSecondaryAction>
                             </ListItem>
-                        )}
+                        ) : null}
                         <ListItem>
                             <ListItemAvatar>
                                 <Avatar>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -115,8 +115,6 @@ class AboutPage extends Component<any, IAboutPageState> {
 
     render() {
         const { classes } = this.props;
-        console.info(this.shouldRenderInstanceContact());
-
         return (
             <div className={classes.pageLayoutConstraints}>
                 <Paper>

--- a/src/utilities/accounts.tsx
+++ b/src/utilities/accounts.tsx
@@ -25,12 +25,6 @@ export function refreshUserAccountData() {
         .catch((err: Error) => {
             console.error(err.message);
         });
-    client.get("/instance").then((resp: any) => {
-        localStorage.setItem(
-            "isPleroma",
-            resp.data.version.match(/Pleroma/) ? "true" : "false"
-        );
-    });
 }
 
 /**


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Makes Pleroma check more dynamic on About page by calling `shouldRenderInstanceContact` method instead of reading from localStorage
- Fixes #69 caused by a regression in account storage settings when making multi-accounts
- Removes `isPleroma` localStorage check in favor of `shouldRenderInstanceContact`
- Removes checking for `account` key changes in localStorage to prevent infinite reloading
- Closes [HD-17]

- [ ] This is a release check.

[HD-17]: https://hyperspacedev.atlassian.net/browse/HD-17