### PR TITLE
[HD-19] Toggle-able Character Limit

### DIFF
--- a/src/pages/Compose.tsx
+++ b/src/pages/Compose.tsx
@@ -39,7 +39,11 @@ import ComposeMediaAttachment from "../components/ComposeMediaAttachment";
 import EmojiPicker from "../components/EmojiPicker";
 import { DateTimePicker, MuiPickersUtilsProvider } from "material-ui-pickers";
 import MomentUtils from "@date-io/moment";
-import { getUserDefaultVisibility, getConfig } from "../utilities/settings";
+import {
+    getUserDefaultVisibility,
+    getConfig,
+    getUserDefaultBool
+} from "../utilities/settings";
 
 interface IComposerState {
     account: UAccount;
@@ -75,7 +79,9 @@ class Composer extends Component<any, IComposerState> {
             sensitive: false,
             visibilityMenu: false,
             text: "",
-            remainingChars: 500,
+            remainingChars: getUserDefaultBool("imposeCharacterLimit")
+                ? 500
+                : 9999999999999,
             showEmojis: false,
             federated: true
         };
@@ -95,7 +101,9 @@ class Composer extends Component<any, IComposerState> {
                 acct: state.acct,
                 visibility: state.visibility,
                 text,
-                remainingChars: 500 - text.length
+                remainingChars: getUserDefaultBool("imposeCharacterLimit")
+                    ? 500 - text.length
+                    : 99999999
             });
         });
     }
@@ -108,7 +116,9 @@ class Composer extends Component<any, IComposerState> {
             acct: state.acct,
             visibility: state.visibility,
             text,
-            remainingChars: 500 - text.length
+            remainingChars: getUserDefaultBool("imposeCharacterLimit")
+                ? 500 - text.length
+                : 99999999
         });
     }
 
@@ -145,7 +155,12 @@ class Composer extends Component<any, IComposerState> {
     }
 
     updateTextFromField(text: string) {
-        this.setState({ text, remainingChars: 500 - text.length });
+        this.setState({
+            text,
+            remainingChars: getUserDefaultBool("imposeCharacterLimit")
+                ? 500 - text.length
+                : 99999999
+        });
     }
 
     updateWarningFromField(sensitiveText: string) {
@@ -467,18 +482,28 @@ class Composer extends Component<any, IComposerState> {
                         }}
                         value={this.state.text}
                     />
-                    <Typography
-                        variant="caption"
-                        className={
-                            this.state.remainingChars <= 100
-                                ? classes.charsReachingLimit
-                                : null
-                        }
-                    >
-                        {`${this.state.remainingChars} character${
-                            this.state.remainingChars === 1 ? "" : "s"
-                        } remaining`}
-                    </Typography>
+                    {getUserDefaultBool("imposeCharacterLimit") ? (
+                        <Typography
+                            variant="caption"
+                            className={
+                                this.state.remainingChars <= 100
+                                    ? classes.charsReachingLimit
+                                    : null
+                            }
+                        >
+                            {`${this.state.remainingChars} character${
+                                this.state.remainingChars === 1 ? "" : "s"
+                            } remaining`}
+                        </Typography>
+                    ) : (
+                        <Typography variant="caption">
+                            <WarningIcon className={classes.warningCaption} />{" "}
+                            You have the character limit turned off. Make sure
+                            that your post matches your instance's character
+                            limit before posting.
+                        </Typography>
+                    )}
+
                     {this.state.attachments &&
                     this.state.attachments.length > 0 ? (
                         <div className={classes.composeAttachmentArea}>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -658,7 +658,9 @@ class SettingsPage extends Component<any, ISettingsState> {
                                             checked={
                                                 this.state.imposeCharacterLimit
                                             }
-                                            onChange={this.toggleCharacterLimit}
+                                            onChange={() =>
+                                                this.toggleCharacterLimit()
+                                            }
                                         />
                                     </ListItemSecondaryAction>
                                 </ListItem>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -63,6 +63,7 @@ import RefreshIcon from "@material-ui/icons/Refresh";
 import UndoIcon from "@material-ui/icons/Undo";
 import DomainDisabledIcon from "@material-ui/icons/DomainDisabled";
 import AccountSettingsIcon from "mdi-material-ui/AccountSettings";
+import AlphabeticalVariantOffIcon from "mdi-material-ui/AlphabeticalVariantOff";
 
 import { Config } from "../types/Config";
 import { Account } from "../types/Account";
@@ -84,6 +85,7 @@ interface ISettingsState {
     brandName: string;
     federated: boolean;
     currentUser?: Account;
+    imposeCharacterLimit: boolean;
 }
 
 class SettingsPage extends Component<any, ISettingsState> {
@@ -114,7 +116,8 @@ class SettingsPage extends Component<any, ISettingsState> {
                 setHyperspaceTheme(defaultTheme),
             defaultVisibility: getUserDefaultVisibility() || "public",
             brandName: "Hyperspace",
-            federated: true
+            federated: true,
+            imposeCharacterLimit: getUserDefaultBool("imposeCharacterLimit")
         };
 
         this.toggleDarkMode = this.toggleDarkMode.bind(this);
@@ -216,6 +219,16 @@ class SettingsPage extends Component<any, ISettingsState> {
         this.setState({
             visibilityDialogOpen: !this.state.visibilityDialogOpen
         });
+    }
+
+    toggleCharacterLimit() {
+        this.setState({
+            imposeCharacterLimit: !this.state.imposeCharacterLimit
+        });
+        setUserDefaultBool(
+            "imposeCharacterLimit",
+            !this.state.imposeCharacterLimit
+        );
     }
 
     toggleResetDialog() {
@@ -630,6 +643,23 @@ class SettingsPage extends Component<any, ISettingsState> {
                                         >
                                             Change
                                         </Button>
+                                    </ListItemSecondaryAction>
+                                </ListItem>
+                                <ListItem>
+                                    <ListItemAvatar>
+                                        <AlphabeticalVariantOffIcon color="action" />
+                                    </ListItemAvatar>
+                                    <ListItemText
+                                        primary="Impose character limit"
+                                        secondary="Impose a character limit when creating posts"
+                                    />
+                                    <ListItemSecondaryAction>
+                                        <Switch
+                                            checked={
+                                                this.state.imposeCharacterLimit
+                                            }
+                                            onChange={this.toggleCharacterLimit}
+                                        />
                                     </ListItemSecondaryAction>
                                 </ListItem>
                             </List>

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -12,6 +12,7 @@ type SettingsTemplate = {
     clearNotificationsOnRead: boolean;
     displayAllOnNotificationBadge: boolean;
     defaultVisibility: string;
+    imposeCharacterLimit: boolean;
 };
 
 /**
@@ -99,7 +100,8 @@ export function createUserDefaults() {
         enablePushNotifications: true,
         clearNotificationsOnRead: false,
         displayAllOnNotificationBadge: false,
-        defaultVisibility: "public"
+        defaultVisibility: "public",
+        imposeCharacterLimit: true
     };
 
     let settings = [
@@ -107,7 +109,8 @@ export function createUserDefaults() {
         "systemDecidesDarkMode",
         "clearNotificationsOnRead",
         "displayAllOnNotificationBadge",
-        "defaultVisibility"
+        "defaultVisibility",
+        "imposeCharacterLimit"
     ];
 
     migrateExistingSettings();


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Adds a new setting key, `imposeCharacterLimit`, to determine whether the default character limit should be imposed (defaults to `true`)
- Adds the settings entry in the Settings page as "Impose character limit"
- Changes the composer window to display a warning instead of the character limit when the limit is turned off
- Changes the default limit when `imposeLimitCharacter` is turned off in Composer to `99999999`
- Closes [HD-19] and #125 

- [ ] This is a release check.

![Screen Shot 2019-11-17 at 14 12 55](https://user-images.githubusercontent.com/13445064/69012564-33857880-0945-11ea-8e5d-c4929f05150a.png)


[HD-19]: https://hyperspacedev.atlassian.net/browse/HD-19