### PR TITLE
[HD-21] Stop emoji picker event crashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperspace",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/EmojiPicker/index.tsx
+++ b/src/components/EmojiPicker/index.tsx
@@ -8,7 +8,12 @@ interface IEmojiPickerProps extends PickerProps {
 
 export class EmojiPicker extends Component<IEmojiPickerProps, any> {
     retrieveFromLocal() {
-        return JSON.parse(localStorage.getItem("emojis") as string);
+        let emojiStorage = localStorage.getItem("emojis");
+        if (emojiStorage != null) {
+            return JSON.parse(emojiStorage as string);
+        } else {
+            return undefined;
+        }
     }
 
     render() {


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Modifies the `retireveFromLocal` function in `EmojiPicker` to return `undefined` when the localStorage item is null/missing.
- Fixes [HD-21]

- [ ] This is a release check.

> Note: should be tested on a server that does _not_ have custom emojis.

[HD-21]: https://hyperspacedev.atlassian.net/browse/HD-21