### PR TITLE
[HD-29] Close drawer after clicking a menu item

### DIFF
--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -648,7 +648,7 @@ export class AppLayout extends Component<any, IAppLayoutState> {
                                 variant="temporary"
                                 anchor={"left"}
                                 open={this.state.drawerOpenOnMobile}
-                                onClose={this.toggleDrawerOnMobile}
+                                onClick={this.toggleDrawerOnMobile}
                                 classes={{ paper: classes.drawerPaper }}
                             >
                                 {this.appDrawer()}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -356,7 +356,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                                 this.state.federated
                                     ? ""
                                     : "(disabled by provider)"
-                            }`}
+                                }`}
                             disabled={!this.state.federated}
                         />
                         <FormControlLabel
@@ -640,8 +640,8 @@ class SettingsPage extends Component<any, ISettingsState> {
                                             )
                                                 ? "Check your browser's notification permissions."
                                                 : browserSupportsNotificationRequests()
-                                                ? "Sends a push notification when not focused."
-                                                : "Notifications aren't supported."
+                                                    ? "Sends a push notification when not focused."
+                                                    : "Notifications aren't supported."
                                         }
                                     />
                                     <ListItemSecondaryAction>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -536,7 +536,38 @@ class SettingsPage extends Component<any, ISettingsState> {
                                 </Toolbar>
                             </div>
                         </div>
-                    ) : null}
+                    ) : (
+                            <div className={classes.pageHeroBackground}>
+                                <div className={classes.pageHeroBackgroundImage} />
+                                <div className={classes.profileContent}>
+                                    <br />
+                                    <Avatar
+                                        className={classes.settingsAvatar}
+                                    />
+                                    <div
+                                        className={classes.profileUserBox}
+                                        style={{ margin: "auto" }}
+                                    >
+                                        <Typography
+                                            className={classes.settingsHeaderText}
+                                            color="inherit"
+                                            component="h1"
+                                        >
+                                            {'Loading ...'}
+                                        </Typography>
+                                        <Typography
+                                            color="inherit"
+                                            className={classes.settingsDetailText}
+                                            component="p"
+                                        >
+                                            @{' ...'}
+                                        </Typography>
+                                    </div>
+                                    <div className={classes.pageGrow} />
+                                    <Toolbar />
+                                </div>
+                            </div>
+                        )}
                     <div className={classes.pageContentLayoutConstraints}>
                         <ListSubheader>Appearance</ListSubheader>
                         <Paper className={classes.pageListConstraints}>


### PR DESCRIPTION
This PR makes the following changes:
- Changes Drawer onClose prop to onClick
- Implements #139 

Not sure if removing onClose breaks anything, please let me know if (you think) it does. Thanks!