### PR TITLE
[HD-30] Adds dummy header to Settings page to prevent layout reposition

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -536,7 +536,38 @@ class SettingsPage extends Component<any, ISettingsState> {
                                 </Toolbar>
                             </div>
                         </div>
-                    ) : null}
+                    ) : (
+                            <div className={classes.pageHeroBackground}>
+                                <div className={classes.pageHeroBackgroundImage} />
+                                <div className={classes.profileContent}>
+                                    <br />
+                                    <Avatar
+                                        className={classes.settingsAvatar}
+                                    />
+                                    <div
+                                        className={classes.profileUserBox}
+                                        style={{ margin: "auto" }}
+                                    >
+                                        <Typography
+                                            className={classes.settingsHeaderText}
+                                            color="inherit"
+                                            component="h1"
+                                        >
+                                            {'Loading...'}
+                                        </Typography>
+                                        <Typography
+                                            color="inherit"
+                                            className={classes.settingsDetailText}
+                                            component="p"
+                                        >
+                                            @{'...'}
+                                        </Typography>
+                                    </div>
+                                    <div className={classes.pageGrow} />
+                                    <Toolbar />
+                                </div>
+                            </div>
+                        )}
                     <div className={classes.pageContentLayoutConstraints}>
                         <ListSubheader>Appearance</ListSubheader>
                         <Paper className={classes.pageListConstraints}>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -356,7 +356,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                                 this.state.federated
                                     ? ""
                                     : "(disabled by provider)"
-                            }`}
+                                }`}
                             disabled={!this.state.federated}
                         />
                         <FormControlLabel
@@ -640,8 +640,8 @@ class SettingsPage extends Component<any, ISettingsState> {
                                             )
                                                 ? "Check your browser's notification permissions."
                                                 : browserSupportsNotificationRequests()
-                                                ? "Sends a push notification when not focused."
-                                                : "Notifications aren't supported."
+                                                    ? "Sends a push notification when not focused."
+                                                    : "Notifications aren't supported."
                                         }
                                     />
                                     <ListItemSecondaryAction>


### PR DESCRIPTION
> ⚠️ **Note**: This PR also covers changes for #140. Changes for both PRs _must_ be approved in order for this PR to be merged. - @alicerunsonfedora 

This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- A ternary operator would either render a loaded profile header, or render nothing. This change renders a loaded profile header, or a "loading" profile header, keeping the rest of the page in the same position. Fixes #142 
- Two prettier formatting changes. Couldn't figure out how to disable this but I guess it follows the formatting guidelines?

Here is what it looks like: 
<img width="594" alt="Screen Shot 2019-12-17 at 8 47 13 PM" src="https://user-images.githubusercontent.com/7794722/71050143-6c666800-2112-11ea-8a1f-47fb3b577bc9.png">
<img width="592" alt="Screen Shot 2019-12-17 at 8 47 17 PM" src="https://user-images.githubusercontent.com/7794722/71050144-6c666800-2112-11ea-9e49-b52246ebe99e.png">

