### PR TITLE
Updates appearance of post/retoot authors

### DIFF
--- a/src/components/Post/Post.styles.tsx
+++ b/src/components/Post/Post.styles.tsx
@@ -81,6 +81,15 @@ export const styles = (theme: Theme) =>
             paddingTop: theme.spacing.unit,
             paddingBottom: theme.spacing.unit
         },
+        postAuthorAccount: {
+            color: theme.palette.grey[500],
+            marginLeft: theme.spacing.unit * 0.5,
+        },
+        postReblogIcon: {
+            marginBottom: theme.spacing.unit * -0.5,
+            marginLeft: theme.spacing.unit * 0.5,
+            marginRight: theme.spacing.unit * 0.5,
+        },
         postAuthorEmoji: {
             height: theme.typography.fontSize,
             verticalAlign: "middle"

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -398,21 +398,34 @@ export class Post extends React.Component<any, IPostState> {
         const { classes } = this.props;
         if (post.reblog) {
             let author = post.reblog.account;
-            let origString = `<span>${author.display_name ||
-                author.username} (@${author.acct}) 🔄 ${post.account
-                .display_name || post.account.username}</span>`;
             let emojis = author.emojis;
             emojis.concat(post.account.emojis);
-            return emojifyString(origString, emojis, classes.postAuthorEmoji);
+            return (
+                <>
+                    <span>
+                        {emojifyString(author.display_name || author.username, author.emojis, classes.postAuthorEmoji)}
+                    </span>
+                    <span className={classes.postAuthorAccount}>
+                        @{emojifyString(author.acct, author.emojis, classes.postAuthorEmoji)}
+                    </span>
+                    <AutorenewIcon fontSize='small' className={classes.postReblogIcon} />
+                    <span>
+                        {emojifyString(post.account.display_name || post.account.username, emojis, classes.postAuthorEmoji)}
+                    </span>
+                </>
+            )
         } else {
             let author = post.account;
-            let origString = `<span>${author.display_name ||
-                author.username} (@${author.acct})</span>`;
-            return emojifyString(
-                origString,
-                author.emojis,
-                classes.postAuthorEmoji
-            );
+            return (
+                <>
+                    <span>
+                        {emojifyString(author.display_name || author.username, author.emojis, classes.postAuthorEmoji)}
+                    </span>
+                    <span className={classes.postAuthorAccount}>
+                        @{emojifyString(author.acct, author.emojis, classes.postAuthorEmoji)}
+                    </span>
+                </>
+            )
         }
     }
 
@@ -656,13 +669,7 @@ export class Post extends React.Component<any, IPostState> {
                                 </IconButton>
                             </Tooltip>
                         }
-                        title={
-                            <Typography
-                                dangerouslySetInnerHTML={{
-                                    __html: this.getReblogAuthors(post)
-                                }}
-                            />
-                        }
+                        title={<Typography>{this.getReblogAuthors(post)}</Typography>}
                         subheader={moment(post.created_at).format(
                             "MMMM Do YYYY [at] h:mm A"
                         )}


### PR DESCRIPTION
This PR makes the following changes:
- Removes parens and changes color of author account name
- Replaces reblog emoji with an icon

Before:
<img width="265" alt="Screen Shot 2019-12-18 at 12 56 53 PM" src="https://user-images.githubusercontent.com/7794722/71111374-4d5de980-2197-11ea-88a2-3317b618590f.png">
After:
<img width="258" alt="Screen Shot 2019-12-18 at 12 56 02 PM" src="https://user-images.githubusercontent.com/7794722/71111403-5a7ad880-2197-11ea-931a-81bfd1470520.png">
Light:
<img width="253" alt="Screen Shot 2019-12-18 at 12 55 25 PM" src="https://user-images.githubusercontent.com/7794722/71111423-61a1e680-2197-11ea-88a1-6da861b9fa9d.png">

I tried to get the account name color to match the timestamp (timestamp is `<Typography color="textSecondary" />`, but was unable to inline `<Typography />` so I settled for `palette.grey[500]`. It may be a bit too light for the light theme :(

I also couldn't figure out how to apply prettier to just a section and not the whole file (vscode was not cooperating) so I apologize for any formatting mistakes.