### PR TITLE
Run certificate installs on CI only if Desktop initiates it

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -16,8 +16,8 @@ jobs:
         run: echo $actor
         env:
           actor: ${{ github.actor }}
-      - name: Run pre-build setup
-        if: github.actor == 'software@marquiskurt.net'
+      - name: Install certificated and entitlements
+        if: github.actor == 'alicerunsonfedora' || github.actor == 'Nomad1556' || github.actor == 'audmaxwell'
         run: |
           echo "Downloading certificates and profiles..."
           echo "$ascCertificates" > certs.b64

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 10.x
       - name: Run pre-build setup
-        if: github.actor == software@marquiskurt.net
+        if: github.actor == 'software@marquiskurt.net'
         run: |
           echo "Downloading certificates and profiles..."
           echo "$ascCertificates" > certs.b64

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: 10.x
       - name: Run pre-build setup
+        if: github.actor == "software@marquiskurt.net"
         run: |
           echo "Downloading certificates and profiles..."
           echo "$ascCertificates" > certs.b64

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 10.x
       - name: Run pre-build setup
-        if: github.actor == "software@marquiskurt.net"
+        if: github.actor = "software@marquiskurt.net"
         run: |
           echo "Downloading certificates and profiles..."
           echo "$ascCertificates" > certs.b64

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -12,6 +12,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
+      - name: Show github.actor
+        run: echo $actor
+        env:
+          actor: ${{ github.actor }}
       - name: Run pre-build setup
         if: github.actor == 'software@marquiskurt.net'
         run: |

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -12,11 +12,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 10.x
-      - name: Show github.actor
-        run: echo $actor
-        env:
-          actor: ${{ github.actor }}
-      - name: Install certificated and entitlements
+      - name: Install certificates and entitlements
         if: github.actor == 'alicerunsonfedora' || github.actor == 'Nomad1556' || github.actor == 'audmaxwell'
         run: |
           echo "Downloading certificates and profiles..."

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 10.x
       - name: Run pre-build setup
-        if: github.actor = "software@marquiskurt.net"
+        if: github.actor == software@marquiskurt.net
         run: |
           echo "Downloading certificates and profiles..."
           echo "$ascCertificates" > certs.b64


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Adds a conditional on the certificate install step in `ci-mac` to only run if a member from the Desktop team initiates it.

- [ ] This is a release check.