### PR TITLE
[HD-39] Fix appearance of author names

### DIFF
--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -396,37 +396,60 @@ export class Post extends React.Component<any, IPostState> {
 
     getReblogAuthors(post: Status) {
         const { classes } = this.props;
-        if (post.reblog) {
-            let author = post.reblog.account;
-            let emojis = author.emojis;
-            emojis.concat(post.account.emojis);
-            return (
-                <>
-                    <span>
-                        {emojifyString(author.display_name || author.username, author.emojis, classes.postAuthorEmoji)}
-                    </span>
-                    <span className={classes.postAuthorAccount}>
-                        @{emojifyString(author.acct, author.emojis, classes.postAuthorEmoji)}
-                    </span>
-                    <AutorenewIcon fontSize='small' className={classes.postReblogIcon} />
-                    <span>
-                        {emojifyString(post.account.display_name || post.account.username, emojis, classes.postAuthorEmoji)}
-                    </span>
-                </>
-            )
-        } else {
-            let author = post.account;
-            return (
-                <>
-                    <span>
-                        {emojifyString(author.display_name || author.username, author.emojis, classes.postAuthorEmoji)}
-                    </span>
-                    <span className={classes.postAuthorAccount}>
-                        @{emojifyString(author.acct, author.emojis, classes.postAuthorEmoji)}
-                    </span>
-                </>
-            )
+
+        let author = post.reblog ? post.reblog.account : post.account;
+        let emojis = author.emojis;
+        let reblogger = post.reblog ? post.account : undefined;
+
+        if (reblogger != undefined) {
+            emojis.concat(reblogger.emojis);
         }
+
+        console.log(post);
+
+        return (
+            <>
+                <span
+                    dangerouslySetInnerHTML={{
+                        __html: emojifyString(
+                            author.display_name || author.username,
+                            emojis,
+                            classes.postAuthorEmoji
+                        )
+                    }}
+                ></span>
+                <span
+                    className={classes.postAuthorAccount}
+                    dangerouslySetInnerHTML={{
+                        __html:
+                            "@" +
+                            emojifyString(
+                                author.acct || author.username,
+                                emojis,
+                                classes.postAuthorEmoji
+                            )
+                    }}
+                ></span>
+                {reblogger ? (
+                    <>
+                        <AutorenewIcon
+                            fontSize="small"
+                            className={classes.postReblogIcon}
+                        />
+                        <span
+                            dangerouslySetInnerHTML={{
+                                __html: emojifyString(
+                                    reblogger.display_name ||
+                                        reblogger.username,
+                                    emojis,
+                                    classes.postAuthorEmoji
+                                )
+                            }}
+                        ></span>
+                    </>
+                ) : null}
+            </>
+        );
     }
 
     getMentions(mention: [Mention]) {
@@ -669,7 +692,11 @@ export class Post extends React.Component<any, IPostState> {
                                 </IconButton>
                             </Tooltip>
                         }
-                        title={<Typography>{this.getReblogAuthors(post)}</Typography>}
+                        title={
+                            <Typography>
+                                {this.getReblogAuthors(post)}
+                            </Typography>
+                        }
                         subheader={moment(post.created_at).format(
                             "MMMM Do YYYY [at] h:mm A"
                         )}


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Re-implements `getReblogAuthors` to properly display images in-line via `dangerouslySetInnerHTML` (Mastodon HTML should already be sanitized, and the only HTML we inject would be fore emojis)
- Fixes regression from #144 
- Addresses #154 and fixes [HD-39]

- [ ] This is a release check.

[HD-39]: https://hyperspacedev.atlassian.net/browse/HD-39