### PR TITLE
[HD-41] loads and loops gif/mp4 "images"

### DIFF
--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -78,9 +78,11 @@ class AttachmentComponent extends Component<
                 );
             case "gifv":
                 return (
-                    <img
+                    <video
+                        autoPlay
+                        loop
                         src={slide.url}
-                        alt={slide.description ? slide.description : ""}
+                        title={slide.description ? slide.description : ""}
                         className={classes.mediaObject}
                     />
                 );


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Uses `video` element to render gifs
- Replaces `alt` attribute with `title`
- fixes #157 and [HD-41](https://hyperspacedev.atlassian.net/browse/HD-41?atlOrigin=eyJpIjoiMjNkMDJlNjg2MTZmNGNlN2JlYzk1N2FjZDVmOTI0MGEiLCJwIjoiaiJ9)

- [ ] This is a release check.