### PR TITLE
[HD-48] Clear text field in state after posting in Compose

### DIFF
--- a/src/pages/Compose.tsx
+++ b/src/pages/Compose.tsx
@@ -626,9 +626,15 @@ class Composer extends Component<any, IComposerState> {
                     : null
             })
 
-            // If we succeed, send a success message and go back.
+            // If we succeed, send a success message, clear the status
+            // text field, and go back.
             .then(() => {
                 this.props.enqueueSnackbar("Posted!");
+
+                // This is necessary to prevent session drafts from saving
+                // posts that were already posted.
+                this.setState({ text: "" });
+
                 window.history.back();
             })
 


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Updates the `post` method in `Compose` to clear the text field after posting a message and before going back.
- Fixes [HD-48] and #166 

- [ ] This is a release check.

[HD-48]: https://hyperspacedev.atlassian.net/browse/HD-48