### PR TITLE
[HD-46] Optimize notifications on smaller device screens

### DIFF
--- a/src/interfaces/overrides.tsx
+++ b/src/interfaces/overrides.tsx
@@ -79,7 +79,7 @@ export const ProfileRoute = (rest: any, component: Component) => (
 export const PrivateRoute = (props: IPrivateRouteProps) => {
     const { component, render, ...rest } = props;
     const redir = (comp: any) =>
-        userLoggedIn ? comp : <Redirect to="/welcome" />;
+        userLoggedIn() ? comp : <Redirect to="/welcome" />;
     return (
         <Route
             {...rest}

--- a/src/interfaces/utils.tsx
+++ b/src/interfaces/utils.tsx
@@ -1,0 +1,3 @@
+export interface Dictionary<T> {
+    [Key: string]: T;
+}

--- a/src/interfaces/utils.tsx
+++ b/src/interfaces/utils.tsx
@@ -1,3 +1,8 @@
+/**
+ * A Generic dictionary with the value of a specific type.
+ *
+ * Keys _must_ be strings.
+ */
 export interface Dictionary<T> {
     [Key: string]: T;
 }

--- a/src/utilities/login.tsx
+++ b/src/utilities/login.tsx
@@ -44,18 +44,18 @@ export function createHyperspaceApp(
 
 /**
  * Gets the appropriate redirect address.
- * @param type The address or configuration to use
+ * @param url The address or configuration to use
  */
 export function getRedirectAddress(
-    type: "desktop" | "dynamic" | string
+    url: "desktop" | "dynamic" | string
 ): string {
-    switch (type) {
+    switch (url) {
         case "desktop":
             return "hyperspace://hyperspace/app/";
         case "dynamic":
             return `https://${window.location.host}`;
         default:
-            return type;
+            return url;
     }
 }
 


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Fixes a bug in the Welcome page where the redirect address would be `null` or `undefined` because the state wasn't loaded (workaround: used `getConfig()`)
- Changes notification appearance in Notifications to show a menu on mobile devices or smaller screens
    - Adds a pop-up menu when clicked on mobile
    - Hides the standard buttons when on a small screen
    - Manages menu notification state with a dictionary of values
- Adds a Generic `Dictionary` type to specify the types of dictionaries

- [ ] This is a release check.