### PR TITLE
[HD-45] Allows unfollowing from the Notifications page

### DIFF
--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -432,7 +432,10 @@ class NotificationsPage extends Component<any, INotificationsPageState> {
                             <MenuItem
                                 onClick={() => this.toggleFollow(notif.account)}
                             >
-                                Follow
+                                {this.state.relationships[notif.account.id]
+                                    .following
+                                    ? "Unfollow"
+                                    : "Follow"}
                             </MenuItem>
                         </>
                     ) : null}


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Stores relationships of notification accounts in state
- Allows unfollowing/toggling from notifications page
- Updates icon and menu label based on un/follow state
- Closes #162 and [HD-45](https://hyperspacedev.atlassian.net/browse/HD-45?atlOrigin=eyJpIjoiMGEwNzdlNTU2NjRiNGUwMWE3ODA0OTIyOTBjM2JlZDQiLCJwIjoiaiJ9)

Made state.relationships mandatory, is this a poor practice? state.notifications is optional/unassigned until willMount...