### PR TITLE
[HD-49] Fixes post author name overflow behavior

### DIFF
--- a/src/components/Post/Post.styles.tsx
+++ b/src/components/Post/Post.styles.tsx
@@ -81,6 +81,9 @@ export const styles = (theme: Theme) =>
             paddingTop: theme.spacing.unit,
             paddingBottom: theme.spacing.unit
         },
+        postAuthorName: {
+            whiteSpace: 'nowrap',
+        },
         postAuthorAccount: {
             color: theme.palette.grey[500],
             marginLeft: theme.spacing.unit * 0.5,

--- a/src/components/Post/Post.styles.tsx
+++ b/src/components/Post/Post.styles.tsx
@@ -17,6 +17,15 @@ export const styles = (theme: Theme) =>
         postReblogMenu: {
             outline: "none"
         },
+        postHeaderContent: {
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+        },
+        postHeaderTitle: {
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            color: theme.palette.text.secondary,
+        },
         postContent: {
             paddingTop: 0,
             paddingBottom: 0,
@@ -83,9 +92,9 @@ export const styles = (theme: Theme) =>
         },
         postAuthorName: {
             whiteSpace: 'nowrap',
+            color: theme.palette.text.primary,
         },
         postAuthorAccount: {
-            color: theme.palette.grey[500],
             marginLeft: theme.spacing.unit * 0.5,
         },
         postReblogIcon: {

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -405,8 +405,6 @@ export class Post extends React.Component<any, IPostState> {
             emojis.concat(reblogger.emojis);
         }
 
-        // console.log(post);
-
         return (
             <>
                 <span
@@ -645,6 +643,10 @@ export class Post extends React.Component<any, IPostState> {
                     elevation={this.props.threadHeader ? 0 : 1}
                 >
                     <CardHeader
+                        classes={{
+                            content: classes.postHeaderContent,
+                            title: classes.postHeaderTitle
+                        }}
                         avatar={
                             <LinkableAvatar
                                 to={`/profile/${
@@ -670,11 +672,7 @@ export class Post extends React.Component<any, IPostState> {
                                 </IconButton>
                             </Tooltip>
                         }
-                        title={
-                            <Typography>
-                                {this.getReblogAuthors(post)}
-                            </Typography>
-                        }
+                        title={this.getReblogAuthors(post)}
                         subheader={moment(post.created_at).format(
                             "MMMM Do YYYY [at] h:mm A"
                         )}

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -410,6 +410,7 @@ export class Post extends React.Component<any, IPostState> {
         return (
             <>
                 <span
+                    className={classes.postAuthorName}
                     dangerouslySetInnerHTML={{
                         __html: emojifyString(
                             author.display_name || author.username,
@@ -431,7 +432,7 @@ export class Post extends React.Component<any, IPostState> {
                     }}
                 ></span>
                 {reblogger ? (
-                    <>
+                    <div>
                         <AutorenewIcon
                             fontSize="small"
                             className={classes.postReblogIcon}
@@ -446,7 +447,7 @@ export class Post extends React.Component<any, IPostState> {
                                 )
                             }}
                         ></span>
-                    </>
+                    </div>
                 ) : null}
             </>
         );


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Prevents author display name from wrapping onto multiple lines.
- Truncates author names line with ellipsis for smaller screens.
- Correctly colors the author account name.
- Resolves #175 and [HD-49](https://hyperspacedev.atlassian.net/browse/HD-49?atlOrigin=eyJpIjoiOWU2ZmU4ZTRkNzdlNDlkZjgxN2RlYTQwNzczNjZjNTYiLCJwIjoiaiJ9)