### PR TITLE
[HD-49] Fixes post author name overflow behavior

### DIFF
--- a/src/components/Post/Post.styles.tsx
+++ b/src/components/Post/Post.styles.tsx
@@ -6,6 +6,9 @@ export const styles = (theme: Theme) =>
             marginTop: theme.spacing.unit,
             marginBottom: theme.spacing.unit
         },
+        postAuthorName: {
+            whiteSpace: 'nowrap',
+        },
         postReblogChip: {
             color: theme.palette.common.white,
             "&:hover": {

--- a/src/components/Post/Post.styles.tsx
+++ b/src/components/Post/Post.styles.tsx
@@ -11,15 +11,21 @@ export const styles = (theme: Theme) =>
             whiteSpace: "nowrap"
         },
         postHeaderTitle: {
-            overflow: "hidden",
-            textOverflow: "ellipsis",
+            display: 'flex',
+            flexWrap: 'wrap',
             color: theme.palette.text.secondary
+        },
+        postAuthorNameAndAccount: {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
         },
         postAuthorName: {
             whiteSpace: "nowrap",
             color: theme.palette.text.primary
         },
         postAuthorAccount: {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
             marginLeft: theme.spacing.unit * 0.5
         },
         postReblogChip: {

--- a/src/components/Post/Post.styles.tsx
+++ b/src/components/Post/Post.styles.tsx
@@ -6,8 +6,21 @@ export const styles = (theme: Theme) =>
             marginTop: theme.spacing.unit,
             marginBottom: theme.spacing.unit
         },
+        postHeaderContent: {
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+        },
+        postHeaderTitle: {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            color: theme.palette.text.secondary,
+        },
         postAuthorName: {
             whiteSpace: 'nowrap',
+            color: theme.palette.text.primary,
+        },
+        postAuthorAccount: {
+            marginLeft: theme.spacing.unit * 0.5,
         },
         postReblogChip: {
             color: theme.palette.common.white,
@@ -84,14 +97,11 @@ export const styles = (theme: Theme) =>
             paddingTop: theme.spacing.unit,
             paddingBottom: theme.spacing.unit
         },
-        postAuthorAccount: {
-            color: theme.palette.grey[500],
-            marginLeft: theme.spacing.unit * 0.5,
-        },
         postReblogIcon: {
             marginBottom: theme.spacing.unit * -0.5,
             marginLeft: theme.spacing.unit * 0.5,
             marginRight: theme.spacing.unit * 0.5,
+            color: theme.palette.text.primary,
         },
         postAuthorEmoji: {
             height: theme.typography.fontSize,

--- a/src/components/Post/Post.styles.tsx
+++ b/src/components/Post/Post.styles.tsx
@@ -11,21 +11,21 @@ export const styles = (theme: Theme) =>
             whiteSpace: "nowrap"
         },
         postHeaderTitle: {
-            display: 'flex',
-            flexWrap: 'wrap',
+            display: "flex",
+            flexWrap: "wrap",
             color: theme.palette.text.secondary
         },
         postAuthorNameAndAccount: {
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
+            overflow: "hidden",
+            textOverflow: "ellipsis"
         },
         postAuthorName: {
             whiteSpace: "nowrap",
             color: theme.palette.text.primary
         },
         postAuthorAccount: {
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
+            overflow: "hidden",
+            textOverflow: "ellipsis",
             marginLeft: theme.spacing.unit * 0.5
         },
         postReblogChip: {

--- a/src/components/Post/Post.styles.tsx
+++ b/src/components/Post/Post.styles.tsx
@@ -7,20 +7,20 @@ export const styles = (theme: Theme) =>
             marginBottom: theme.spacing.unit
         },
         postHeaderContent: {
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
+            overflow: "hidden",
+            whiteSpace: "nowrap"
         },
         postHeaderTitle: {
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            color: theme.palette.text.secondary,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            color: theme.palette.text.secondary
         },
         postAuthorName: {
-            whiteSpace: 'nowrap',
-            color: theme.palette.text.primary,
+            whiteSpace: "nowrap",
+            color: theme.palette.text.primary
         },
         postAuthorAccount: {
-            marginLeft: theme.spacing.unit * 0.5,
+            marginLeft: theme.spacing.unit * 0.5
         },
         postReblogChip: {
             color: theme.palette.common.white,
@@ -101,7 +101,7 @@ export const styles = (theme: Theme) =>
             marginBottom: theme.spacing.unit * -0.5,
             marginLeft: theme.spacing.unit * 0.5,
             marginRight: theme.spacing.unit * 0.5,
-            color: theme.palette.text.primary,
+            color: theme.palette.text.primary
         },
         postAuthorEmoji: {
             height: theme.typography.fontSize,

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -647,6 +647,10 @@ export class Post extends React.Component<any, IPostState> {
                 elevation={this.props.threadHeader ? 0 : 1}
             >
                 <CardHeader
+                    classes={{
+                        content: classes.postHeaderContent,
+                        title: classes.postHeaderTitle,
+                    }}
                     avatar={
                         <LinkableAvatar
                             to={`/profile/${
@@ -673,7 +677,7 @@ export class Post extends React.Component<any, IPostState> {
                         </Tooltip>
                     }
                     title={
-                        <Typography>{this.getReblogAuthors(post)}</Typography>
+                        this.getReblogAuthors(post)
                     }
                     subheader={moment(post.created_at).format(
                         "MMMM Do YYYY [at] h:mm A"

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -412,28 +412,30 @@ export class Post extends React.Component<any, IPostState> {
 
         return (
             <>
-                <span
-                    className={classes.postAuthorName}
-                    dangerouslySetInnerHTML={{
-                        __html: emojifyString(
-                            author.display_name || author.username,
-                            emojis,
-                            classes.postAuthorEmoji
-                        )
-                    }}
-                ></span>
-                <span
-                    className={classes.postAuthorAccount}
-                    dangerouslySetInnerHTML={{
-                        __html:
-                            "@" +
-                            emojifyString(
-                                author.acct || author.username,
+                <span className={classes.postAuthorNameAndAccount}>
+                    <span
+                        className={classes.postAuthorName}
+                        dangerouslySetInnerHTML={{
+                            __html: emojifyString(
+                                author.display_name || author.username,
                                 emojis,
                                 classes.postAuthorEmoji
                             )
-                    }}
-                ></span>
+                        }}
+                    ></span>
+                    <span
+                        className={classes.postAuthorAccount}
+                        dangerouslySetInnerHTML={{
+                            __html:
+                                "@" +
+                                emojifyString(
+                                    author.acct || author.username,
+                                    emojis,
+                                    classes.postAuthorEmoji
+                                )
+                        }}
+                    ></span>
+                </span>
                 {reblogger ? (
                     <div>
                         <AutorenewIcon

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -649,7 +649,7 @@ export class Post extends React.Component<any, IPostState> {
                 <CardHeader
                     classes={{
                         content: classes.postHeaderContent,
-                        title: classes.postHeaderTitle,
+                        title: classes.postHeaderTitle
                     }}
                     avatar={
                         <LinkableAvatar
@@ -676,9 +676,7 @@ export class Post extends React.Component<any, IPostState> {
                             </IconButton>
                         </Tooltip>
                     }
-                    title={
-                        this.getReblogAuthors(post)
-                    }
+                    title={this.getReblogAuthors(post)}
                     subheader={moment(post.created_at).format(
                         "MMMM Do YYYY [at] h:mm A"
                     )}

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -410,11 +410,10 @@ export class Post extends React.Component<any, IPostState> {
             emojis.concat(reblogger.emojis);
         }
 
-        // console.log(post);
-
         return (
             <>
                 <span
+                    className={classes.postAuthorName}
                     dangerouslySetInnerHTML={{
                         __html: emojifyString(
                             author.display_name || author.username,
@@ -436,7 +435,7 @@ export class Post extends React.Component<any, IPostState> {
                     }}
                 ></span>
                 {reblogger ? (
-                    <>
+                    <div>
                         <AutorenewIcon
                             fontSize="small"
                             className={classes.postReblogIcon}
@@ -451,7 +450,7 @@ export class Post extends React.Component<any, IPostState> {
                                 )
                             }}
                         ></span>
-                    </>
+                    </div>
                 ) : null}
             </>
         );


### PR DESCRIPTION
This PR makes the following changes:
- Prevents author display name from wrapping onto multiple lines.
- Truncates author names line with ellipsis for smaller screens.
- Correctly colors the author account name.
- Resolves #175 and HD-49