### PR TITLE
Auto-set localhost:3000 URL when testing

### DIFF
--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -140,11 +140,17 @@ export async function getConfig(): Promise<Config | undefined> {
         let { location } = resp.data;
 
         if (!location.endsWith("/")) {
-            console.warn(
+            console.info(
                 "Location does not have a backslash, so Hyperspace has added it automatically."
             );
             resp.data.location = location + "/";
         }
+
+        if (process.env.NODE_ENV === "development") {
+            resp.data.location = "http://localhost:3000/";
+            console.info("Location field has been updated to localhost:3000.");
+        }
+
         return resp.data as Config;
     } catch (err) {
         console.error(


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Updates the `getConfig` function to automatically change the location field in a config to `"http://localhost:3000"` if being run through `react-scripts` (via checking `process.env.NODE_ENV`)
- Changes console warns in `getConfig` to console info

- [ ] This is a release check.