### PR TITLE
[HD-56] Notification system overhaul (Part 1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ import Composer from "./pages/Compose";
 import WelcomePage from "./pages/Welcome";
 import MessagesPage from "./pages/Messages";
 import RecommendationsPage from "./pages/Recommendations";
-import Missingno from "./pages/Missingno";
 import Blocked from "./pages/Blocked";
 import You from "./pages/You";
 import RequestsPage from "./pages/Requests";
@@ -86,8 +85,6 @@ class App extends Component<any, IAppState> {
     }
 
     render() {
-        const { classes } = this.props;
-
         this.removeBodyBackground();
 
         return (

--- a/src/components/Attachment/Attachment.tsx
+++ b/src/components/Attachment/Attachment.tsx
@@ -91,7 +91,11 @@ class AttachmentComponent extends Component<
                 );
             case "unknown":
                 return (
-                    <object data={slide.url} className={classes.mediaObject} />
+                    <object
+                        data={slide.url}
+                        className={classes.mediaObject}
+                        aria-label={`Slide: ${slide.id}`}
+                    />
                 );
         }
     }

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -6,7 +6,6 @@ import {
     LinearProgress,
     Tooltip
 } from "@material-ui/core";
-import { LinkableIconButton } from "../../interfaces/overrides";
 
 import FastRewindIcon from "@material-ui/icons/FastRewind";
 import FastForwardIcon from "@material-ui/icons/FastForward";

--- a/src/components/ComposeMediaAttachment/ComposeMediaAttachment.tsx
+++ b/src/components/ComposeMediaAttachment/ComposeMediaAttachment.tsx
@@ -68,7 +68,10 @@ class ComposeMediaAttachment extends Component<
                 ) : attachment.type === "video" ? (
                     <video autoPlay={false} src={attachment.url} />
                 ) : (
-                    <object data={attachment.url} />
+                    <object
+                        data={attachment.url}
+                        aria-label={`Attachment: ${attachment.id}`}
+                    />
                 )}
                 <GridListTileBar
                     classes={{ title: classes.attachmentBar }}

--- a/src/components/EmojiPicker/index.tsx
+++ b/src/components/EmojiPicker/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Picker, PickerProps, CustomEmoji } from "emoji-mart";
+import { Picker, PickerProps } from "emoji-mart";
 import "emoji-mart/css/emoji-mart.css";
 
 interface IEmojiPickerProps extends PickerProps {

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -25,8 +25,7 @@ import {
     RadioGroup,
     Tooltip,
     Typography,
-    withStyles,
-    Zoom
+    withStyles
 } from "@material-ui/core";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 import ReplyIcon from "@material-ui/icons/Reply";
@@ -102,7 +101,7 @@ export class Post extends React.Component<any, IPostState> {
     }
 
     shouldComponentUpdate(nextProps: any, nextState: any) {
-        if (nextState == this.state) return false;
+        if (nextState === this.state) return false;
         return true;
     }
 
@@ -406,7 +405,7 @@ export class Post extends React.Component<any, IPostState> {
         let emojis = author.emojis;
         let reblogger = post.reblog ? post.account : undefined;
 
-        if (reblogger != undefined) {
+        if (reblogger !== undefined) {
             emojis.concat(reblogger.emojis);
         }
 
@@ -801,7 +800,7 @@ export class Post extends React.Component<any, IPostState> {
                                     variant: "success"
                                 }),
                             onShareError: (error: Error) => {
-                                if (error.name != "AbortError")
+                                if (error.name !== "AbortError")
                                     this.props.enqueueSnackbar(
                                         `Couldn't share post: ${error.name}`,
                                         { variant: "error" }

--- a/src/pages/Compose.tsx
+++ b/src/pages/Compose.tsx
@@ -193,9 +193,9 @@ class Composer extends Component<any, IComposerState> {
             let fileList: File[] = [];
             if (thePasteEvent.clipboardData != null) {
                 let clipitems = thePasteEvent.clipboardData.items;
-                if (clipitems != undefined) {
+                if (clipitems !== undefined) {
                     for (let i = 0; i < clipitems.length; i++) {
-                        if (clipitems[i].type.indexOf("image") != -1) {
+                        if (clipitems[i].type.indexOf("image") !== -1) {
                             let clipfile = clipitems[i].getAsFile();
                             if (clipfile != null) {
                                 fileList.push(clipfile);
@@ -395,9 +395,9 @@ class Composer extends Component<any, IComposerState> {
     getOnlyMediaIds() {
         let ids: string[] = [];
         if (this.state.attachments) {
-            this.state.attachments.map((attachment: Attachment) => {
-                ids.push(attachment.id);
-            });
+            return this.state.attachments.map(
+                (attachment: Attachment) => attachment.id
+            );
         }
         return ids;
     }
@@ -494,7 +494,7 @@ class Composer extends Component<any, IComposerState> {
             this.setState({
                 poll: poll
             });
-        } else if (this.state.poll && this.state.poll.options.length == 4) {
+        } else if (this.state.poll && this.state.poll.options.length === 4) {
             this.props.enqueueSnackbar(
                 "You've reached the options limit in your poll.",
                 { variant: "error" }

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -8,7 +8,6 @@ import {
     ListItemText,
     CircularProgress,
     ListItemAvatar,
-    Avatar,
     ListItemSecondaryAction,
     Tooltip,
     Typography

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import {
+    Link,
     List,
     ListItem,
     ListItemText,
@@ -422,7 +423,7 @@ class NotificationsPage extends Component<any, INotificationsPageState> {
                     )}
                     onClose={() => this.toggleMobileMenu(notif.id)}
                 >
-                    {notif.type == "follow" ? (
+                    {notif.type === "follow" ? (
                         <>
                             <LinkableMenuItem
                                 to={`profile/${notif.account.id}`}
@@ -439,7 +440,7 @@ class NotificationsPage extends Component<any, INotificationsPageState> {
                             </MenuItem>
                         </>
                     ) : null}
-                    {notif.type == "mention" && notif.status ? (
+                    {notif.type === "mention" && notif.status ? (
                         <LinkableMenuItem
                             to={`/compose?reply=${
                                 notif.status.reblog
@@ -609,6 +610,17 @@ class NotificationsPage extends Component<any, INotificationsPageState> {
                 ) : (
                     <span />
                 )}
+
+                <div
+                    className={classes.pageLayoutEmptyTextConstraints}
+                    style={{ textAlign: "center" }}
+                >
+                    <Typography>
+                        <Link href="/#/settings#sp-notifications">
+                            Manage notification settings
+                        </Link>
+                    </Typography>
+                </div>
 
                 <Dialog
                     open={this.state.deleteDialogOpen}

--- a/src/pages/PageLayout.styles.tsx
+++ b/src/pages/PageLayout.styles.tsx
@@ -1,4 +1,4 @@
-import { Theme, createStyles, FormHelperText } from "@material-ui/core";
+import { Theme, createStyles } from "@material-ui/core";
 import { isDarwinApp } from "../utilities/desktop";
 import { isAppbarExpanded } from "../utilities/appbar";
 

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -3,7 +3,6 @@ import {
     withStyles,
     Typography,
     Avatar,
-    Divider,
     Button,
     CircularProgress,
     Paper,

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -6,7 +6,6 @@ import {
     ListSubheader,
     ListItemSecondaryAction,
     ListItemAvatar,
-    Avatar,
     Paper,
     withStyles,
     Typography,
@@ -14,7 +13,7 @@ import {
     Tooltip,
     IconButton
 } from "@material-ui/core";
-import PersonIcon from "@material-ui/icons/Person";
+
 import AssignmentIndIcon from "@material-ui/icons/AssignmentInd";
 import PersonAddIcon from "@material-ui/icons/PersonAdd";
 import { styles } from "./PageLayout.styles";

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -38,19 +38,15 @@ import {
 } from "../utilities/settings";
 import {
     canSendNotifications,
-    browserSupportsNotificationRequests
+    browserSupportsNotificationRequests,
+    getNotificationRequestPermission
 } from "../utilities/notifications";
 import { themes, defaultTheme } from "../types/HyperspaceTheme";
 import ThemePreview from "../components/ThemePreview";
-import {
-    setHyperspaceTheme,
-    getHyperspaceTheme,
-    getDarkModeFromSystem
-} from "../utilities/themes";
+import { setHyperspaceTheme, getHyperspaceTheme } from "../utilities/themes";
 import { Visibility } from "../types/Visibility";
-import { LinkableButton, LinkableIconButton } from "../interfaces/overrides";
+import { LinkableIconButton } from "../interfaces/overrides";
 
-import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 import DevicesIcon from "@material-ui/icons/Devices";
 import Brightness3Icon from "@material-ui/icons/Brightness3";
 import PaletteIcon from "@material-ui/icons/Palette";
@@ -71,6 +67,7 @@ import { Config } from "../types/Config";
 import { Account } from "../types/Account";
 import Mastodon from "megalodon";
 import { isDarwinApp } from "../utilities/desktop";
+import { withSnackbar } from "notistack";
 
 interface ISettingsState {
     darkModeEnabled: boolean;
@@ -139,6 +136,14 @@ class SettingsPage extends Component<any, ISettingsState> {
         this.setVisibility = this.setVisibility.bind(this);
     }
 
+    componentWillReceiveProps() {
+        const path = window.location.hash.split("#");
+        if (document.getElementById(path[path.length - 1]) !== null) {
+            document.getElementById(path[path.length - 1])?.scrollIntoView();
+            window.scrollBy(0, -64);
+        }
+    }
+
     componentDidMount() {
         getConfig()
             .then((config: any) => {
@@ -168,6 +173,12 @@ class SettingsPage extends Component<any, ISettingsState> {
                     console.error(err.message);
                 }
             });
+
+        const path = window.location.hash.split("#");
+        if (document.getElementById(path[path.length - 1]) !== null) {
+            document.getElementById(path[path.length - 1])?.scrollIntoView();
+            window.scrollBy(0, -64);
+        }
     }
 
     getFederatedStatus() {
@@ -199,14 +210,44 @@ class SettingsPage extends Component<any, ISettingsState> {
         window.location.reload();
     }
 
+    /**
+     * Toggle the setting for enabling/disabling push notifications.
+     *
+     * If the notification permission wasn't set yet (i.e., `Notification.permission`)
+     * is in `"default"` state, get the permission request first.
+     */
     togglePushNotifications() {
-        this.setState({
-            pushNotificationsEnabled: !this.state.pushNotificationsEnabled
-        });
-        setUserDefaultBool(
-            "enablePushNotifications",
-            !this.state.pushNotificationsEnabled
-        );
+        if (Notification.permission === "default") {
+            getNotificationRequestPermission()
+                .then(permission => {
+                    if (permission === "granted") {
+                        setUserDefaultBool(
+                            "enablePushNotifications",
+                            !this.state.pushNotificationsEnabled
+                        );
+                        this.setState({
+                            pushNotificationsEnabled: !this.state
+                                .pushNotificationsEnabled
+                        });
+                    } else if (permission === "denied") {
+                        this.props.enqueueSnackbar(
+                            "Permission request was denied.",
+                            { variant: "error" }
+                        );
+                    }
+                })
+                .catch(reason =>
+                    this.props.enqueueSnackbar(reason, { variant: "error" })
+                );
+        } else {
+            setUserDefaultBool(
+                "enablePushNotifications",
+                !this.state.pushNotificationsEnabled
+            );
+            this.setState({
+                pushNotificationsEnabled: !this.state.pushNotificationsEnabled
+            });
+        }
     }
 
     toggleBadgeCount() {
@@ -297,6 +338,227 @@ class SettingsPage extends Component<any, ISettingsState> {
         });
         window.location.reload();
     }
+
+    settingsList = () => {
+        const { classes } = this.props;
+        return (
+            <>
+                <ListSubheader id="sp-appearance">Appearance</ListSubheader>
+                <Paper className={classes.pageListConstraints}>
+                    <List>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <DevicesIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Match system appearance"
+                                secondary="Follows your device's preferences to toggle dark mode"
+                            />
+                            <ListItemSecondaryAction>
+                                <Switch
+                                    checked={this.state.systemDecidesDarkMode}
+                                    onChange={this.toggleSystemDarkMode}
+                                />
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        {!this.state.systemDecidesDarkMode ? (
+                            <ListItem>
+                                <ListItemAvatar>
+                                    <Brightness3Icon color="action" />
+                                </ListItemAvatar>
+                                <ListItemText
+                                    primary="Dark mode"
+                                    secondary="Toggles light or dark theme"
+                                />
+                                <ListItemSecondaryAction>
+                                    <Switch
+                                        disabled={
+                                            this.state.systemDecidesDarkMode
+                                        }
+                                        checked={this.state.darkModeEnabled}
+                                        onChange={this.toggleDarkMode}
+                                    />
+                                </ListItemSecondaryAction>
+                            </ListItem>
+                        ) : null}
+
+                        <ListItem>
+                            <ListItemAvatar>
+                                <PaletteIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Interface theme"
+                                secondary="Defines the color palette used for the interface"
+                            />
+                            <ListItemSecondaryAction>
+                                <Button onClick={this.toggleThemeDialog}>
+                                    Set theme
+                                </Button>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+
+                        <ListItem>
+                            <ListItemAvatar>
+                                <DashboardIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Show more posts"
+                                secondary="Shows additional columns of posts on wider screens"
+                            />
+                            <ListItemSecondaryAction>
+                                <Switch
+                                    checked={this.state.masonryLayout}
+                                    onChange={this.toggleMasonryLayout}
+                                />
+                            </ListItemSecondaryAction>
+                        </ListItem>
+
+                        <ListItem>
+                            <ListItemAvatar>
+                                <InfiniteIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Enable infinite scroll"
+                                secondary="Automatically load more posts when scrolling"
+                            />
+                            <ListItemSecondaryAction>
+                                <Switch
+                                    checked={this.state.infiniteScroll}
+                                    onChange={this.toggleInfiniteScroll}
+                                />
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                    </List>
+                </Paper>
+                <br />
+                <ListSubheader id="sp-composer">Composer</ListSubheader>
+                <Paper className={classes.pageListConstraints}>
+                    <List>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <VisibilityIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Default post visibility"
+                                secondary="Creating posts in the composer will use this visiblity"
+                            />
+                            <ListItemSecondaryAction>
+                                <Button onClick={this.toggleVisibilityDialog}>
+                                    Change
+                                </Button>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <AlphabeticalVariantOffIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Impose character limit"
+                                secondary="Impose a character limit when creating posts"
+                            />
+                            <ListItemSecondaryAction>
+                                <Switch
+                                    checked={this.state.imposeCharacterLimit}
+                                    onChange={() => this.toggleCharacterLimit()}
+                                />
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                    </List>
+                </Paper>
+                <br />
+                <ListSubheader id="sp-notifications">
+                    Notifications
+                </ListSubheader>
+                <Paper className={classes.pageListConstraints}>
+                    <List>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <NotificationsIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Enable push notifications"
+                                secondary={
+                                    getUserDefaultBool("userDeniedNotification")
+                                        ? "Check your browser's notification permissions."
+                                        : browserSupportsNotificationRequests()
+                                        ? "Sends a push notification when not focused."
+                                        : "Notifications aren't supported."
+                                }
+                            />
+                            <ListItemSecondaryAction>
+                                <Switch
+                                    checked={
+                                        this.state.pushNotificationsEnabled
+                                    }
+                                    onChange={this.togglePushNotifications}
+                                    disabled={
+                                        !browserSupportsNotificationRequests()
+                                    }
+                                />
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <BellAlertIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Notification badge counts all notifications"
+                                secondary={
+                                    "Counts all notifications, read or unread."
+                                }
+                            />
+                            <ListItemSecondaryAction>
+                                <Switch
+                                    checked={this.state.badgeDisplaysAllNotifs}
+                                    onChange={this.toggleBadgeCount}
+                                />
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                    </List>
+                </Paper>
+                <br />
+                <ListSubheader id="sp-advanced">Advanced</ListSubheader>
+                <Paper className={classes.pageListConstraints}>
+                    <List>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <RefreshIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary="Refresh settings"
+                                secondary="Resets the settings to defaults."
+                            />
+                            <ListItemSecondaryAction>
+                                <Button
+                                    onClick={() =>
+                                        this.toggleResetSettingsDialog()
+                                    }
+                                >
+                                    Refresh
+                                </Button>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <UndoIcon color="action" />
+                            </ListItemAvatar>
+                            <ListItemText
+                                primary={`Reset ${this.state.brandName}`}
+                                secondary="Deletes all data and resets the app"
+                            />
+                            <ListItemSecondaryAction>
+                                <Button
+                                    onClick={() => this.toggleResetDialog()}
+                                >
+                                    Reset
+                                </Button>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                    </List>
+                </Paper>
+            </>
+        );
+    };
 
     showThemeDialog() {
         const { classes } = this.props;
@@ -608,245 +870,7 @@ class SettingsPage extends Component<any, ISettingsState> {
                         </div>
                     )}
                     <div className={classes.pageContentLayoutConstraints}>
-                        <ListSubheader>Appearance</ListSubheader>
-                        <Paper className={classes.pageListConstraints}>
-                            <List>
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <DevicesIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary="Match system appearance"
-                                        secondary="Follows your device's preferences to toggle dark mode"
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Switch
-                                            checked={
-                                                this.state.systemDecidesDarkMode
-                                            }
-                                            onChange={this.toggleSystemDarkMode}
-                                        />
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-                                {!this.state.systemDecidesDarkMode ? (
-                                    <ListItem>
-                                        <ListItemAvatar>
-                                            <Brightness3Icon color="action" />
-                                        </ListItemAvatar>
-                                        <ListItemText
-                                            primary="Dark mode"
-                                            secondary="Toggles light or dark theme"
-                                        />
-                                        <ListItemSecondaryAction>
-                                            <Switch
-                                                disabled={
-                                                    this.state
-                                                        .systemDecidesDarkMode
-                                                }
-                                                checked={
-                                                    this.state.darkModeEnabled
-                                                }
-                                                onChange={this.toggleDarkMode}
-                                            />
-                                        </ListItemSecondaryAction>
-                                    </ListItem>
-                                ) : null}
-
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <PaletteIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary="Interface theme"
-                                        secondary="Defines the color palette used for the interface"
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Button
-                                            onClick={this.toggleThemeDialog}
-                                        >
-                                            Set theme
-                                        </Button>
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <DashboardIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary="Show more posts"
-                                        secondary="Shows additional columns of posts on wider screens"
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Switch
-                                            checked={this.state.masonryLayout}
-                                            onChange={this.toggleMasonryLayout}
-                                        />
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <InfiniteIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary="Enable infinite scroll"
-                                        secondary="Automatically load more posts when scrolling"
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Switch
-                                            checked={this.state.infiniteScroll}
-                                            onChange={this.toggleInfiniteScroll}
-                                        />
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-                            </List>
-                        </Paper>
-                        <br />
-                        <ListSubheader>Composer</ListSubheader>
-                        <Paper className={classes.pageListConstraints}>
-                            <List>
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <VisibilityIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary="Default post visibility"
-                                        secondary="Creating posts in the composer will use this visiblity"
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Button
-                                            onClick={
-                                                this.toggleVisibilityDialog
-                                            }
-                                        >
-                                            Change
-                                        </Button>
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <AlphabeticalVariantOffIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary="Impose character limit"
-                                        secondary="Impose a character limit when creating posts"
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Switch
-                                            checked={
-                                                this.state.imposeCharacterLimit
-                                            }
-                                            onChange={() =>
-                                                this.toggleCharacterLimit()
-                                            }
-                                        />
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-                            </List>
-                        </Paper>
-                        <br />
-                        <ListSubheader>Notifications</ListSubheader>
-                        <Paper className={classes.pageListConstraints}>
-                            <List>
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <NotificationsIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary="Enable push notifications"
-                                        secondary={
-                                            getUserDefaultBool(
-                                                "userDeniedNotification"
-                                            )
-                                                ? "Check your browser's notification permissions."
-                                                : browserSupportsNotificationRequests()
-                                                ? "Sends a push notification when not focused."
-                                                : "Notifications aren't supported."
-                                        }
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Switch
-                                            checked={
-                                                this.state
-                                                    .pushNotificationsEnabled
-                                            }
-                                            onChange={
-                                                this.togglePushNotifications
-                                            }
-                                            disabled={
-                                                !browserSupportsNotificationRequests() ||
-                                                getUserDefaultBool(
-                                                    "userDeniedNotification"
-                                                )
-                                            }
-                                        />
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <BellAlertIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary="Notification badge counts all notifications"
-                                        secondary={
-                                            "Counts all notifications, read or unread."
-                                        }
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Switch
-                                            checked={
-                                                this.state
-                                                    .badgeDisplaysAllNotifs
-                                            }
-                                            onChange={this.toggleBadgeCount}
-                                        />
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-                            </List>
-                        </Paper>
-                        <br />
-                        <ListSubheader>Advanced</ListSubheader>
-                        <Paper className={classes.pageListConstraints}>
-                            <List>
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <RefreshIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary="Refresh settings"
-                                        secondary="Resets the settings to defaults."
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Button
-                                            onClick={() =>
-                                                this.toggleResetSettingsDialog()
-                                            }
-                                        >
-                                            Refresh
-                                        </Button>
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-                                <ListItem>
-                                    <ListItemAvatar>
-                                        <UndoIcon color="action" />
-                                    </ListItemAvatar>
-                                    <ListItemText
-                                        primary={`Reset ${this.state.brandName}`}
-                                        secondary="Deletes all data and resets the app"
-                                    />
-                                    <ListItemSecondaryAction>
-                                        <Button
-                                            onClick={() =>
-                                                this.toggleResetDialog()
-                                            }
-                                        >
-                                            Reset
-                                        </Button>
-                                    </ListItemSecondaryAction>
-                                </ListItem>
-                            </List>
-                        </Paper>
+                        {this.settingsList()}
                         {this.showThemeDialog()}
                         {this.showVisibilityDialog()}
                         {this.showResetDialog()}
@@ -858,4 +882,4 @@ class SettingsPage extends Component<any, ISettingsState> {
     }
 }
 
-export default withStyles(styles)(SettingsPage);
+export default withStyles(styles)(withSnackbar(SettingsPage));

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -137,8 +137,9 @@ class SettingsPage extends Component<any, ISettingsState> {
 
     componentWillReceiveProps() {
         const path = window.location.hash.split("#");
-        if (document.getElementById(path[path.length - 1]) !== null) {
-            document.getElementById(path[path.length - 1])?.scrollIntoView();
+        const lastPath = document.getElementById(path[path.length - 1]);
+        if (lastPath !== null) {
+            lastPath.scrollIntoView();
             window.scrollBy(0, -64);
         }
     }
@@ -174,8 +175,9 @@ class SettingsPage extends Component<any, ISettingsState> {
             });
 
         const path = window.location.hash.split("#");
-        if (document.getElementById(path[path.length - 1]) !== null) {
-            document.getElementById(path[path.length - 1])?.scrollIntoView();
+        const lastPath = document.getElementById(path[path.length - 1]);
+        if (lastPath !== null) {
+            lastPath.scrollIntoView();
             window.scrollBy(0, -64);
         }
     }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -66,7 +66,6 @@ import InfiniteIcon from "@material-ui/icons/AllInclusive";
 import { Config } from "../types/Config";
 import { Account } from "../types/Account";
 import Mastodon from "megalodon";
-import { isDarwinApp } from "../utilities/desktop";
 import { withSnackbar } from "notistack";
 
 interface ISettingsState {

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -36,12 +36,11 @@ import axios from "axios";
 import { withSnackbar, withSnackbarProps } from "notistack";
 import { Config } from "../types/Config";
 import {
-    addAccountToRegistry,
     getAccountRegistry,
     loginWithAccount,
     removeAccountFromRegistry
 } from "../utilities/accounts";
-import { Account, MultiAccount } from "../types/Account";
+import { MultiAccount } from "../types/Account";
 
 import AccountCircleIcon from "@material-ui/icons/AccountCircle";
 import CloseIcon from "@material-ui/icons/Close";
@@ -255,10 +254,10 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                         license: config.license.url,
                         repo: config.repository,
                         defaultRedirectAddress:
-                            config.location != "dynamic"
+                            config.location !== "dynamic"
                                 ? config.location
                                 : `https://${window.location.host}`,
-                        redirectAddressIsDynamic: config.location == "dynamic",
+                        redirectAddressIsDynamic: config.location === "dynamic",
                         version: config.version
                     });
                 }
@@ -651,7 +650,7 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
                 );
 
                 getConfig().then((resp: any) => {
-                    if (resp == undefined) {
+                    if (resp === undefined) {
                         return;
                     }
 
@@ -920,7 +919,6 @@ class WelcomePage extends Component<IWelcomeProps, IWelcomeState> {
      * Show the emergency login panel
      */
     showAuthDialog() {
-        const { classes } = this.props;
         return (
             <Dialog
                 open={this.state.openAuthDialog}

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -1,5 +1,4 @@
 import { defaultTheme, themes } from "../types/HyperspaceTheme";
-import { getNotificationRequestPermission } from "./notifications";
 import axios from "axios";
 import { Config } from "../types/Config";
 import { Visibility } from "../types/Visibility";
@@ -13,6 +12,7 @@ type SettingsTemplate = {
     displayAllOnNotificationBadge: boolean;
     defaultVisibility: string;
     imposeCharacterLimit: boolean;
+    canSendNotifications: boolean;
 };
 
 /**
@@ -102,7 +102,8 @@ export function createUserDefaults() {
         displayAllOnNotificationBadge: false,
         defaultVisibility: "public",
         imposeCharacterLimit: true,
-        isMasonryLayout: false
+        isMasonryLayout: false,
+        canSendNotifications: false
     };
 
     let settings = [
@@ -112,7 +113,8 @@ export function createUserDefaults() {
         "displayAllOnNotificationBadge",
         "defaultVisibility",
         "imposeCharacterLimit",
-        "isMasonryLayout"
+        "isMasonryLayout",
+        "canSendNotifications"
     ];
 
     migrateExistingSettings();
@@ -126,7 +128,6 @@ export function createUserDefaults() {
             }
         }
     });
-    getNotificationRequestPermission();
 }
 
 /**

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -128,6 +128,8 @@ export function createUserDefaults() {
             }
         }
     });
+
+    setUserDefaultBool("userDeniedNotications", false);
 }
 
 /**


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Changes behavior of default setting generation to automatically disable push notifications instead of prompting for permission immediately
- Fixes warnings found with @typescript/eslint
- Make `getNotificationRequestPermission` return a Promise
- Change toggle behavior of push notifications in Settings
  - If no permissions were set, prompt for permission
  - Otherwise, read from the set permission
- Adds anchors to list subheaders in Settings for navigation purposes
- Adds quick link to notification settings on notifications page
- Implements first two tiers of [HD-56]

- [ ] This is a release check.

> Note: This PR relies on #185.

[HD-56]: https://hyperspacedev.atlassian.net/browse/HD-56