### PR TITLE
Filter out "desktop" and "dynamic" in location

### DIFF
--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -146,9 +146,12 @@ export async function getConfig(): Promise<Config | undefined> {
 
         let { location }: { location: string } = resp.data;
 
-        if (!location.endsWith("/") && (location !== "desktop" && location !== "dynamic")) {
+        if (
+            !location.endsWith("/") &&
+            (location !== "desktop" && location !== "dynamic")
+        ) {
             console.info(
-                "Location does not have a backslash, so Hyperspace has added it automatically."
+                "Location does not have a forward slash, so Hyperspace has added it automatically."
             );
             resp.data.location = location + "/";
         }

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -133,16 +133,20 @@ export function createUserDefaults() {
 }
 
 /**
- * Gets the configuration data from `config.json`
+ * Gets the configuration data from `config.json`.
+ *
+ * In scenarios where the app is being run from the desktop or from a local React server
+ * started by react-scripts, the location field is adjusted accordingly.
+ *
  * @returns The Promise data from getting the config.
  */
 export async function getConfig(): Promise<Config | undefined> {
     try {
         const resp = await axios.get("config.json");
 
-        let { location } = resp.data;
+        let { location }: { location: string } = resp.data;
 
-        if (!location.endsWith("/")) {
+        if (!location.endsWith("/") && (location !== "desktop" && location !== "dynamic")) {
             console.info(
                 "Location does not have a backslash, so Hyperspace has added it automatically."
             );


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Updates `getConfig` to not apply a backslash when location is set to `desktop` or `dynamic`

- [ ] This is a release check.