### PR TITLE
Update about page configurations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperspace",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13719,9 +13719,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "megalodon": "^0.6.4",
         "moment": "^2.24.0",
         "notistack": "^0.5.1",
-        "prettier": "1.18.2",
+        "prettier": "^1.19.1",
         "query-string": "^6.11.1",
         "react": "^16.13.0",
         "react-dom": "^16.13.0",

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -28,6 +28,8 @@ import CodeIcon from "@material-ui/icons/Code";
 import TicketAccountIcon from "mdi-material-ui/TicketAccount";
 import EditIcon from "@material-ui/icons/Edit";
 import VpnKeyIcon from "@material-ui/icons/VpnKey";
+import BugReportIcon from "@material-ui/icons/BugReport";
+import ForumIcon from "@material-ui/icons/Forum";
 
 import { styles } from "./PageLayout.styles";
 import { Instance } from "../types/Instance";
@@ -84,7 +86,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                     let account = resp.data;
                     this.setState({
                         hyperspaceAdmin: account,
-                        hyperspaceAdminName: config.admin.name,
+                        hyperspaceAdminName: config.admin.name
                     });
                 })
                 .catch((err: Error) => {
@@ -124,9 +126,8 @@ class AboutPage extends Component<any, IAboutPageState> {
                     <div
                         className={classes.instanceHeaderPaper}
                         style={{
-                            backgroundImage: `url("${
-                                this.state.brandBg ?? ""
-                            }")`
+                            backgroundImage: `url("${this.state.brandBg ??
+                                ""}")`
                         }}
                     >
                         <div className={classes.instanceToolbar}>
@@ -142,18 +143,38 @@ class AboutPage extends Component<any, IAboutPageState> {
                                     </IconButton>
                                 </Tooltip>
                             ) : null}
+                            <Tooltip title="Submit a bug report">
+                                <IconButton
+                                    href={
+                                        "https://github.com/hyperspacedev/hyperspace/issues/new?assignees=&labels=&template=bug_report.md&title=%5BBug%5D+Issue+title"
+                                    }
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    color="inherit"
+                                >
+                                    <BugReportIcon />
+                                </IconButton>
+                            </Tooltip>
+                            <Tooltip title="Request a feature">
+                                <IconButton
+                                    href={
+                                        "https://github.com/hyperspacedev/hyperspace/issues/new?assignees=&labels=&template=feature_request.md&title=%5BRequest%5D+Request+title"
+                                    }
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    color="inherit"
+                                >
+                                    <ForumIcon />
+                                </IconButton>
+                            </Tooltip>
                         </div>
                         <div className={classes.instanceHeaderText}>
                             <Typography variant="h4" component="p">
-                                {this.state.brandName
-                                    ? this.state.brandName
-                                    : "Hyperspace Desktop"}
+                                {this.state.brandName ?? "Hyperspace Desktop"}
                             </Typography>
                             <Typography>
                                 Version{" "}
-                                {`${
-                                    this.state.versionNumber ?? "1.1.x"
-                                } ${
+                                {`${this.state.versionNumber ?? "1.1.x"} ${
                                     this.state &&
                                     this.state.brandName !== "Hyperspace"
                                         ? "(Hyperspace-like)"
@@ -165,25 +186,24 @@ class AboutPage extends Component<any, IAboutPageState> {
                     <List className={classes.pageListConstraints}>
                         <ListItem>
                             <ListItemAvatar>
-                                {
-                                    this.state.hyperspaceAdmin ?
+                                {this.state.hyperspaceAdmin ? (
                                     <LinkableAvatar
-                                    to={`/profile/${
-                                        this.state.hyperspaceAdmin?.id ?? 0
-                                    }`}
-                                    src={
-                                        this.state.hyperspaceAdmin?.avatar_static ?? ""
-                                    }
-                                >
-                                    <PersonIcon />
-                                </LinkableAvatar>
-                                : <ListItemAvatar>
-                                    <Avatar>
+                                        to={`/profile/${this.state
+                                            .hyperspaceAdmin?.id ?? 0}`}
+                                        src={
+                                            this.state.hyperspaceAdmin
+                                                ?.avatar_static ?? ""
+                                        }
+                                    >
                                         <PersonIcon />
-                                    </Avatar>
+                                    </LinkableAvatar>
+                                ) : (
+                                    <ListItemAvatar>
+                                        <Avatar>
+                                            <PersonIcon />
+                                        </Avatar>
                                     </ListItemAvatar>
-                                }
-
+                                )}
                             </ListItemAvatar>
                             <ListItemText
                                 primary="App provider"
@@ -194,39 +214,34 @@ class AboutPage extends Component<any, IAboutPageState> {
                                           this.state.hyperspaceAdmin
                                               .display_name ||
                                           "@" + this.state.hyperspaceAdmin.acct
-                                        :
-                                            this.state.hyperspaceAdminName
-                                            ?? "No provider set in config"
+                                        : this.state.hyperspaceAdminName ??
+                                          "No provider set in config"
                                 }
                             />
-                            {
-                                this.state.hyperspaceAdmin?
+                            {this.state.hyperspaceAdmin ? (
                                 <ListItemSecondaryAction>
-                                <Tooltip title="Send a post or message">
-                                    <LinkableIconButton
-                                        to={`/compose?visibility=${
-                                            this.state.federated
-                                                ? "public"
-                                                : "private"
-                                        }&acct=${
-                                            this.state.hyperspaceAdmin?.acct ?? ""
-                                        }`}
-                                    >
-                                        <ChatIcon />
-                                    </LinkableIconButton>
-                                </Tooltip>
-                                <Tooltip title="View profile">
-                                    <LinkableIconButton
-                                        to={`/profile/${
-                                           this.state.hyperspaceAdmin?.id ?? 0
-                                        }`}
-                                    >
-                                        <AssignmentIndIcon />
-                                    </LinkableIconButton>
-                                </Tooltip>
-                            </ListItemSecondaryAction>
-                            : null
-                            }
+                                    <Tooltip title="Send a post or message">
+                                        <LinkableIconButton
+                                            to={`/compose?visibility=${
+                                                this.state.federated
+                                                    ? "public"
+                                                    : "private"
+                                            }&acct=${this.state.hyperspaceAdmin
+                                                ?.acct ?? ""}`}
+                                        >
+                                            <ChatIcon />
+                                        </LinkableIconButton>
+                                    </Tooltip>
+                                    <Tooltip title="View profile">
+                                        <LinkableIconButton
+                                            to={`/profile/${this.state
+                                                .hyperspaceAdmin?.id ?? 0}`}
+                                        >
+                                            <AssignmentIndIcon />
+                                        </LinkableIconButton>
+                                    </Tooltip>
+                                </ListItemSecondaryAction>
+                            ) : null}
                         </ListItem>
                         <ListItem>
                             <ListItemAvatar>
@@ -276,9 +291,8 @@ class AboutPage extends Component<any, IAboutPageState> {
                     <div
                         className={classes.instanceHeaderPaper}
                         style={{
-                            backgroundImage: `url("${
-                                this.state.instance?.thumbnail ?? ""
-                            }")`
+                            backgroundImage: `url("${this.state.instance
+                                ?.thumbnail ?? ""}")`
                         }}
                     >
                         <IconButton
@@ -344,9 +358,8 @@ class AboutPage extends Component<any, IAboutPageState> {
                                     </Tooltip>
                                     <Tooltip title="View profile">
                                         <LinkableIconButton
-                                            to={`/profile/${
-                                                this.state.instance?.contact_account.id ?? 0
-                                            }`}
+                                            to={`/profile/${this.state.instance
+                                                ?.contact_account.id ?? 0}`}
                                         >
                                             <AssignmentIndIcon />
                                         </LinkableIconButton>
@@ -467,12 +480,12 @@ class AboutPage extends Component<any, IAboutPageState> {
                 <div className={classes.pageLayoutFooter}>
                     <Typography variant="caption">
                         (C) {new Date().getFullYear()}{" "}
-                        {this.state.brandName ?? "Hyperspace"}{" "}
-                        developers. All rights reserved.
+                        {this.state.brandName ?? "Hyperspace"} developers. All
+                        rights reserved.
                     </Typography>
                     <Typography variant="caption" paragraph>
-                        {this.state.brandName ?? "Hyperspace"}{" "}
-                        Desktop is made possible by the{" "}
+                        {this.state.brandName ?? "Hyperspace"} Desktop is made
+                        possible by the{" "}
                         <Link
                             href={"https://material-ui.com"}
                             target="_blank"

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -98,11 +98,9 @@ class AboutPage extends Component<any, IAboutPageState> {
                 .finally(() => {
                     this.setState({
                         federation: config.federation,
-                        developer: config.developer ? config.developer : false,
+                        developer: config.developer ?? false,
                         versionNumber: config.version,
-                        brandName: config.branding
-                            ? config.branding.name
-                            : "Hyperspace",
+                        brandName: config.branding.name ?? "Hyperspace",
                         brandBg: config.branding.background,
                         license: {
                             name: config.license.name,
@@ -115,11 +113,7 @@ class AboutPage extends Component<any, IAboutPageState> {
     }
 
     shouldRenderInstanceContact(): boolean {
-        if (this.state.instance != null) {
-            return this.state.instance.version.match(/Pleroma/) == null;
-        } else {
-            return false;
-        }
+        return this.state.instance?.version?.match(/Pleroma/) == null ?? false;
     }
 
     render() {
@@ -131,7 +125,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                         className={classes.instanceHeaderPaper}
                         style={{
                             backgroundImage: `url("${
-                                this.state.brandBg ? this.state.brandBg : ""
+                                this.state.brandBg ?? ""
                             }")`
                         }}
                     >
@@ -158,9 +152,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                             <Typography>
                                 Version{" "}
                                 {`${
-                                    this.state
-                                        ? this.state.versionNumber
-                                        : "1.0.x"
+                                    this.state.versionNumber ?? "1.1.x"
                                 } ${
                                     this.state &&
                                     this.state.brandName !== "Hyperspace"
@@ -177,15 +169,10 @@ class AboutPage extends Component<any, IAboutPageState> {
                                     this.state.hyperspaceAdmin ?
                                     <LinkableAvatar
                                     to={`/profile/${
-                                        this.state.hyperspaceAdmin
-                                            ? this.state.hyperspaceAdmin.id
-                                            : 0
+                                        this.state.hyperspaceAdmin?.id ?? 0
                                     }`}
                                     src={
-                                        this.state.hyperspaceAdmin
-                                            ? this.state.hyperspaceAdmin
-                                                  .avatar_static
-                                            : ""
+                                        this.state.hyperspaceAdmin?.avatar_static ?? ""
                                     }
                                 >
                                     <PersonIcon />
@@ -222,10 +209,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                                                 ? "public"
                                                 : "private"
                                         }&acct=${
-                                            this.state.hyperspaceAdmin
-                                                ? this.state.hyperspaceAdmin
-                                                      .acct
-                                                : ""
+                                            this.state.hyperspaceAdmin?.acct ?? ""
                                         }`}
                                     >
                                         <ChatIcon />
@@ -234,9 +218,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                                 <Tooltip title="View profile">
                                     <LinkableIconButton
                                         to={`/profile/${
-                                            this.state.hyperspaceAdmin
-                                                ? this.state.hyperspaceAdmin.id
-                                                : 0
+                                           this.state.hyperspaceAdmin?.id ?? 0
                                         }`}
                                     >
                                         <AssignmentIndIcon />
@@ -295,10 +277,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                         className={classes.instanceHeaderPaper}
                         style={{
                             backgroundImage: `url("${
-                                this.state.instance &&
-                                this.state.instance.thumbnail
-                                    ? this.state.instance.thumbnail
-                                    : ""
+                                this.state.instance?.thumbnail ?? ""
                             }")`
                         }}
                     >
@@ -313,15 +292,11 @@ class AboutPage extends Component<any, IAboutPageState> {
                         </IconButton>
                         <div className={classes.instanceHeaderText}>
                             <Typography variant="h4" component="p">
-                                {this.state.instance
-                                    ? this.state.instance.uri
-                                    : "Loading..."}
+                                {this.state.instance?.uri ?? "Loading..."}
                             </Typography>
                             <Typography>
                                 Server version{" "}
-                                {this.state.instance
-                                    ? this.state.instance.version
-                                    : "x.x.x"}
+                                {this.state.instance?.version ?? "x.x.x"}
                             </Typography>
                         </div>
                     </div>
@@ -370,10 +345,7 @@ class AboutPage extends Component<any, IAboutPageState> {
                                     <Tooltip title="View profile">
                                         <LinkableIconButton
                                             to={`/profile/${
-                                                this.state.instance
-                                                    ? this.state.instance
-                                                          .contact_account.id
-                                                    : 0
+                                                this.state.instance?.contact_account.id ?? 0
                                             }`}
                                         >
                                             <AssignmentIndIcon />
@@ -452,8 +424,8 @@ class AboutPage extends Component<any, IAboutPageState> {
                                 secondary={
                                     this.state.federation &&
                                     this.state.federation.enablePublicTimeline
-                                        ? "This instance is federated."
-                                        : "This instance is not federated."
+                                        ? "This copy of Hyperspace is federated."
+                                        : "This copy of Hyperspace is not federated."
                                 }
                             />
                         </ListItem>
@@ -468,8 +440,8 @@ class AboutPage extends Component<any, IAboutPageState> {
                                 secondary={
                                     this.state.federation &&
                                     this.state.federation.universalLogin
-                                        ? "This instance supports universal login."
-                                        : "This instance does not support universal login."
+                                        ? "This copy of Hyperspace supports universal login."
+                                        : "This copy of Hyperspace does not support universal login."
                                 }
                             />
                         </ListItem>
@@ -484,8 +456,8 @@ class AboutPage extends Component<any, IAboutPageState> {
                                 secondary={
                                     this.state.federation &&
                                     this.state.federation.allowPublicPosts
-                                        ? "This instance allows posting publicly."
-                                        : "This instance does not allow posting publicly."
+                                        ? "This copy of Hyperspace allows posting publicly."
+                                        : "This copy of Hyperspace does not allow posting publicly."
                                 }
                             />
                         </ListItem>
@@ -495,11 +467,11 @@ class AboutPage extends Component<any, IAboutPageState> {
                 <div className={classes.pageLayoutFooter}>
                     <Typography variant="caption">
                         (C) {new Date().getFullYear()}{" "}
-                        {this.state ? this.state.brandName : "Hyperspace"}{" "}
+                        {this.state.brandName ?? "Hyperspace"}{" "}
                         developers. All rights reserved.
                     </Typography>
                     <Typography variant="caption" paragraph>
-                        {this.state ? this.state.brandName : "Hyperspace"}{" "}
+                        {this.state.brandName ?? "Hyperspace"}{" "}
                         Desktop is made possible by the{" "}
                         <Link
                             href={"https://material-ui.com"}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -85,6 +85,18 @@ class AboutPage extends Component<any, IAboutPageState> {
                     this.setState({
                         hyperspaceAdmin: account,
                         hyperspaceAdminName: config.admin.name,
+                    });
+                })
+                .catch((err: Error) => {
+                    console.error(err.message);
+                    if (true) {
+                        this.setState({
+                            hyperspaceAdminName: `Could not find ${config.admin.name} on ${config.registration.defaultInstance}`
+                        });
+                    }
+                })
+                .finally(() => {
+                    this.setState({
                         federation: config.federation,
                         developer: config.developer ? config.developer : false,
                         versionNumber: config.version,
@@ -98,9 +110,6 @@ class AboutPage extends Component<any, IAboutPageState> {
                         },
                         repository: config.repository
                     });
-                })
-                .catch((err: Error) => {
-                    console.error(err.message);
                 });
         });
     }
@@ -164,7 +173,9 @@ class AboutPage extends Component<any, IAboutPageState> {
                     <List className={classes.pageListConstraints}>
                         <ListItem>
                             <ListItemAvatar>
-                                <LinkableAvatar
+                                {
+                                    this.state.hyperspaceAdmin ?
+                                    <LinkableAvatar
                                     to={`/profile/${
                                         this.state.hyperspaceAdmin
                                             ? this.state.hyperspaceAdmin.id
@@ -179,6 +190,13 @@ class AboutPage extends Component<any, IAboutPageState> {
                                 >
                                     <PersonIcon />
                                 </LinkableAvatar>
+                                : <ListItemAvatar>
+                                    <Avatar>
+                                        <PersonIcon />
+                                    </Avatar>
+                                    </ListItemAvatar>
+                                }
+
                             </ListItemAvatar>
                             <ListItemText
                                 primary="App provider"
@@ -189,10 +207,14 @@ class AboutPage extends Component<any, IAboutPageState> {
                                           this.state.hyperspaceAdmin
                                               .display_name ||
                                           "@" + this.state.hyperspaceAdmin.acct
-                                        : "No provider set in config"
+                                        :
+                                            this.state.hyperspaceAdminName
+                                            ?? "No provider set in config"
                                 }
                             />
-                            <ListItemSecondaryAction>
+                            {
+                                this.state.hyperspaceAdmin?
+                                <ListItemSecondaryAction>
                                 <Tooltip title="Send a post or message">
                                     <LinkableIconButton
                                         to={`/compose?visibility=${
@@ -221,6 +243,8 @@ class AboutPage extends Component<any, IAboutPageState> {
                                     </LinkableIconButton>
                                 </Tooltip>
                             </ListItemSecondaryAction>
+                            : null
+                            }
                         </ListItem>
                         <ListItem>
                             <ListItemAvatar>


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Resolves an issue where config.json doesn't load into the page's state when an admin account isn't loaded correctly by moving non-account state updates to a `finally` statement (fixes #200)
- Reactors parts of the About page to use optional chaining and nullish coalescing
- Adds bug report and feature requests buttons to app card in About
- Rewords "instance" to "copy of Hyperspace" in the Federation status section
- Updates Prettier dependency to support nullish coalescing and optional chaining

- [ ] This is a release check.