### PR TITLE
Add '@' symbol adornment, refactor Welcome

### DIFF
--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -148,7 +148,8 @@ export async function getConfig(): Promise<Config | undefined> {
 
         if (
             !location.endsWith("/") &&
-            location !== "desktop" && location !== "dynamic"
+            location !== "desktop" &&
+            location !== "dynamic"
         ) {
             console.info(
                 "Location does not have a forward slash, so Hyperspace has added it automatically."

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -148,7 +148,7 @@ export async function getConfig(): Promise<Config | undefined> {
 
         if (
             !location.endsWith("/") &&
-            (location !== "desktop" && location !== "dynamic")
+            location !== "desktop" && location !== "dynamic"
         ) {
             console.info(
                 "Location does not have a forward slash, so Hyperspace has added it automatically."


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Adds an adornment in front of the username field on the Welcome page to prevent sign-in ambiguity
- Refactors parts of the Welcome page to use nullish coalescing and optionals where appropriate

- [ ] This is a release check.

<img width="540" alt="Screen Shot 2020-05-18 at 10 59 58" src="https://user-images.githubusercontent.com/13445064/82229870-f5b7db80-98f8-11ea-94fa-369b65375c8b.png">
