### PR TITLE
Return out of notification toggle when browser is unsupported

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -218,7 +218,9 @@ class SettingsPage extends Component<any, ISettingsState> {
      * is in `"default"` state, get the permission request first.
      */
     togglePushNotifications() {
-        if (!browserSupportsNotificationRequests()) { return; }
+        if (!browserSupportsNotificationRequests()) {
+            return;
+        }
         if (Notification.permission === "default") {
             getNotificationRequestPermission()
                 .then(permission => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -218,6 +218,7 @@ class SettingsPage extends Component<any, ISettingsState> {
      * is in `"default"` state, get the permission request first.
      */
     togglePushNotifications() {
+        if (!browserSupportsNotificationRequests()) { return; }
         if (Notification.permission === "default") {
             getNotificationRequestPermission()
                 .then(permission => {

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -148,7 +148,8 @@ export async function getConfig(): Promise<Config | undefined> {
 
         if (
             !location.endsWith("/") &&
-            location !== "desktop" && location !== "dynamic"
+            location !== "desktop" &&
+            location !== "dynamic"
         ) {
             console.info(
                 "Location does not have a forward slash, so Hyperspace has added it automatically."

--- a/src/utilities/settings.tsx
+++ b/src/utilities/settings.tsx
@@ -148,7 +148,7 @@ export async function getConfig(): Promise<Config | undefined> {
 
         if (
             !location.endsWith("/") &&
-            (location !== "desktop" && location !== "dynamic")
+            location !== "desktop" && location !== "dynamic"
         ) {
             console.info(
                 "Location does not have a forward slash, so Hyperspace has added it automatically."


### PR DESCRIPTION
This PR makes the following changes:

<!-- List your changes here as a bullet list. Read the contribution guidelines for more details.-->

- Attempts to address or close #206 
- Updates `togglePushNotifications` in Settings.tsx to return if the browser does not support notifications for any given reason:  https://github.com/hyperspacedev/hyperspace/blob/f52daad91c5c2b258880a2afcea7a624c41f195e/src/pages/Settings.tsx#L220-L222 

- [ ] This is a release check.